### PR TITLE
Added image type check to tlvupgrade

### DIFF
--- a/tools/sparrow/trailertool.py
+++ b/tools/sparrow/trailertool.py
@@ -45,7 +45,6 @@ def get_version(inc):
     return ''.join(version)
 
 def get_crc(data):
-#    crc32 = binascii.crc32(data[0:-4]) & 0xffffffff
     crc32 = binascii.crc32(data) & 0xffffffff
     return crc32
 


### PR DESCRIPTION
Added image type verification to OTA upload tool. The bootloader will not boot on an image with wrong image type so it is no security issue but it is unnecessary to even try with the wrong image type.
