### PR TITLE
Automatic dual-op mode, CoAP resources, simple web server for node

### DIFF
--- a/apps/mote-res/resources-coap/Makefile.resources-coap
+++ b/apps/mote-res/resources-coap/Makefile.resources-coap
@@ -1,0 +1,5 @@
+ifdef COAP_NO_SENSORS
+  resources-coap_src = resource-ipv6-neighbors.c resource-ipv6-routes.c resource-rpl-info.c
+else
+  resources-coap_src = resource-temperature.c resource-ipv6-neighbors.c resource-ipv6-routes.c resource-rpl-info.c resource-led.c resource-button-event.c
+endif

--- a/apps/mote-res/resources-coap/README
+++ b/apps/mote-res/resources-coap/README
@@ -1,0 +1,44 @@
+Libcoap client demo:
+-------------------------------------------------------------------------------
+Use the following instructions in order to run a simple coap-client demo from command line [Linux terminal]
+
+1. Download and extract libcoap-4.1.1.tar.gz
+2. Install libcoap in your home directory by calling ./configure and ./make
+3. Switch to the example folder, where the coap-client and coap-server application should be already built.
+4. Run the coap-client with no arguments: this will show the application usage.
+5. Start the border router and the remote node as usual.
+6. GET the well-known resource at the remote node, to discover the installed resoures [the IPv6 address should be the address of the remote node]:
+      ./coap-client -m get coap://[aaaa::212:4b00:40f:595a]/.well-known/core
+7. GET any installed resource in the same way. Currently only text/plain type is supported, so the CLI command is simple:
+      ./coap-client -m get coap://[aaaa::212:4b00:40f:595a]/toggle-led
+   Here, we ask for the status of the LED; the resource is called "toggle-led"
+8. PUSH or PUT requests for installed resources are executed similarly. For example:
+      ./coap-client -m put -e led=toggle coap://[aaaa::212:4b00:40f:595a]/toggle-led
+   Here we request a toggle of the device LED
+
+--------------------------------------------------------------------------------
+
+Resources currently installed:
+
+1. Toggle the user LED:
+
+   Get the status of the LED:
+     ./coap-client -m get coap://[aaaa::212:4b00:40f:595a]/toggle-led
+
+   Toggle the LED:
+     ./coap-client -m put e- led=toogle coap://[aaaa::212:4b00:40f:595a]/toggle-led
+
+2. Get the list of IPv6 neighbors of an IPv6 node:
+     ./coap-client -m get coap://[aaaa::212:4b00:40f:595a]/ipv6/neighbors
+
+3. Get specific  RPL information:
+
+  - Address of the parent node:
+     ./coap-client -m post -e info=parent coap://[aaaa::212:4b00:40f:595a]/rpl/info
+
+  - Rank of a node:
+     ./coap-client -m post -e info=rank coap://[aaaa::212:4b00:40f:595a]/rpl/info
+
+  - Link metric of node-parent link:
+     ./coap-client -m post -e info=link_metric coap://[aaaa::212:4b00:40f:595a]/rpl/info
+

--- a/apps/mote-res/resources-coap/resource-button-event.c
+++ b/apps/mote-res/resources-coap/resource-button-event.c
@@ -1,0 +1,88 @@
+/* Copyright (c) 2015, Yanzi Networks AB.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holders nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ * USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ */
+
+#include <string.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include "rest-engine.h"
+#include "er-coap.h"
+
+#define DEBUG 0
+#if DEBUG
+#include <stdio.h>
+#define PRINTF(...) printf(__VA_ARGS__)
+#define SPRINT6ADDR(addr) sprint_addr6(buf, addr)
+#else
+#define PRINTF(...)
+#define SPRINT6ADDR(addr)
+#endif
+
+static uint32_t event_counter = 0;
+/*---------------------------------------------------------------------------*/
+static void res_get_handler(void *request, void *response, uint8_t *buffer,
+  uint16_t preferred_size, int32_t *offset);
+static void res_event_handler(void);
+/*---------------------------------------------------------------------------*/
+/*
+ * Event CoAP resource definition.
+ */
+EVENT_RESOURCE(resource_push_button_event,
+  "title=\"Push event\";obs",
+  res_get_handler,
+  NULL,
+  NULL,
+  NULL,
+  res_event_handler);
+/*---------------------------------------------------------------------------*/
+static void
+res_get_handler(void *request, void *response, uint8_t *buffer,
+  uint16_t preferred_size, int32_t *offset)
+{
+  char message[REST_MAX_CHUNK_SIZE];
+  memset(message, 0, REST_MAX_CHUNK_SIZE);
+  snprintf(message, REST_MAX_CHUNK_SIZE - 1, "Push event no: %lu\n",
+           (unsigned long)event_counter);
+
+  REST.set_header_content_type(response, REST.type.TEXT_PLAIN);
+  memcpy(buffer, &message[0], strlen(message));
+  REST.set_response_payload(response, buffer, strlen(message));
+}
+/*---------------------------------------------------------------------------*/
+static void
+res_event_handler(void)
+{
+  /* Increment event counter */
+  ++event_counter;
+
+  /* Notify the registered observers which will trigger
+   * the res_get_handler to create the response.
+   */
+  REST.notify_subscribers(&resource_push_button_event);
+}
+/*---------------------------------------------------------------------------*/

--- a/apps/mote-res/resources-coap/resource-ipv6-neighbors.c
+++ b/apps/mote-res/resources-coap/resource-ipv6-neighbors.c
@@ -1,0 +1,96 @@
+/* Copyright (c) 2015, Yanzi Networks AB.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holders nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ * USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ */
+
+#include "resources-coap.h"
+#include "contiki-net.h"
+#include "rest-engine.h"
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+static void res_get_handler(void *request, void *response, uint8_t *buffer,
+  uint16_t preferred_size, int32_t *offset);
+
+/*---------------------------------------------------------------------------*/
+static uint16_t
+print_neighbors(char *msg)
+{
+  uip_ds6_nbr_t *nbr = nbr_table_head(ds6_neighbors);
+  while (nbr != NULL) {
+    if (strlen(msg) > REST_MAX_CHUNK_SIZE) {
+      return strlen(msg);
+    }
+    sprint_addr6(msg, &nbr->ipaddr);
+    sprintf(msg+strlen(msg), "\n");
+    nbr = nbr_table_next(ds6_neighbors, nbr);
+  }
+  return strlen(msg);
+}
+/*---------------------------------------------------------------------------*/
+/*
+ * Declare the IPv6 neighbors resource
+ */
+RESOURCE(resource_ipv6_neighbors,
+  "title=\"IPV6-Neighbors: ?len=0..\";rt=\"Text\"",
+  res_get_handler,
+  NULL,
+  NULL,
+  NULL);
+/*---------------------------------------------------------------------------*/
+static void
+res_get_handler(void *request, void *response, uint8_t *buffer,
+  uint16_t preferred_size, int32_t *offset)
+{
+  const char *len = NULL;
+  char message[2*REST_MAX_CHUNK_SIZE];
+  memset(message, 0, 2*REST_MAX_CHUNK_SIZE);
+  print_neighbors(&message[0]);
+
+  int length = strlen(&message[0]);
+
+  /* The query string can be retrieved by rest_get_query(),
+   * or parsed for its key-value pairs.
+   */
+  if(REST.get_query_variable(request, "len", &len)) {
+    length = atoi(len);
+    if(length < 0) {
+      length = 0;
+    }
+    if(length > REST_MAX_CHUNK_SIZE) {
+      length = REST_MAX_CHUNK_SIZE;
+    }
+    memcpy(buffer, message, length);
+  } else {
+    memcpy(buffer, message, length);
+  }
+  REST.set_header_content_type(response, REST.type.TEXT_PLAIN);
+  REST.set_header_etag(response, (uint8_t *)&length, 1);
+  REST.set_response_payload(response, buffer, length);
+}
+/*---------------------------------------------------------------------------*/

--- a/apps/mote-res/resources-coap/resource-ipv6-routes.c
+++ b/apps/mote-res/resources-coap/resource-ipv6-routes.c
@@ -1,0 +1,97 @@
+/* Copyright (c) 2015, Yanzi Networks AB.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holders nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ * USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ */
+
+#include "resources-coap.h"
+#include "contiki-net.h"
+#include "rest-engine.h"
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+static void res_get_handler(void *request, void *response, uint8_t *buffer,
+  uint16_t preferred_size, int32_t *offset);
+
+/*---------------------------------------------------------------------------*/
+static uint16_t
+print_routes(char *msg, int size)
+{
+  uip_ds6_route_t *r = uip_ds6_route_head();
+  int len = strlen(msg);
+  while(r != NULL && len < size + 30) {
+    /* output a route entry */
+    len += sprint_addr6(&msg[len], &r->ipaddr);
+    len += snprintf(&msg[len], size, "->");
+    len += sprint_addr6(&msg[len], uip_ds6_route_nexthop(r));
+    len += snprintf(&msg[len], size, "\n");
+    r = uip_ds6_route_next(r);
+  }
+  return len;
+}
+/*---------------------------------------------------------------------------*/
+/*
+ * Declare the IPv6 neighbors resource
+ */
+RESOURCE(resource_ipv6_routes,
+  "title=\"IPV6-Routes: ?len=0..\";rt=\"Text\"",
+  res_get_handler,
+  NULL,
+  NULL,
+  NULL);
+/*---------------------------------------------------------------------------*/
+static void
+res_get_handler(void *request, void *response, uint8_t *buffer,
+  uint16_t preferred_size, int32_t *offset)
+{
+  const char *len = NULL;
+  char message[2*REST_MAX_CHUNK_SIZE];
+  memset(message, 0, 2*REST_MAX_CHUNK_SIZE);
+  print_routes(&message[0], 2*REST_MAX_CHUNK_SIZE);
+
+  int length = strlen(&message[0]);
+
+  /* The query string can be retrieved by rest_get_query(),
+   * or parsed for its key-value pairs.
+   */
+  if(REST.get_query_variable(request, "len", &len)) {
+    length = atoi(len);
+    if(length < 0) {
+      length = 0;
+    }
+    if(length > REST_MAX_CHUNK_SIZE) {
+      length = REST_MAX_CHUNK_SIZE;
+    }
+    memcpy(buffer, message, length);
+  } else {
+    memcpy(buffer, message, length);
+  }
+  REST.set_header_content_type(response, REST.type.TEXT_PLAIN);
+  REST.set_header_etag(response, (uint8_t *)&length, 1);
+  REST.set_response_payload(response, buffer, length);
+}
+/*---------------------------------------------------------------------------*/

--- a/apps/mote-res/resources-coap/resource-led.c
+++ b/apps/mote-res/resources-coap/resource-led.c
@@ -1,0 +1,285 @@
+/*
+ * Copyright (c) 2015, Yanzi Networks AB.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holders nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ * USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ */
+
+#include "contiki-net.h"
+#include "rest-engine.h"
+#include "er-coap.h"
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "dev/leds.h"
+
+#ifdef RESOURCE_LED_CONF_LED
+#define RESOURCE_LED RESOURCE_LED_CONF_LED
+#else
+#define RESOURCE_LED LEDS_YELLOW
+#endif
+
+#define RESOURCE_LED0 RESOURCE_LED
+
+#ifdef RESOURCE_LED1_CONF_LED
+#define RESOURCE_LED1 RESOURCE_LED1_CONF_LED
+#else
+#define RESOURCE_LED1 LEDS_GREEN
+#endif
+
+static void res_get_handler(void *request, void *response, uint8_t *buffer,
+  uint16_t preferred_size, int32_t *offset);
+static void res_post_handler(void *request, void *response,
+  uint8_t *buffer, uint16_t preferred_size, int32_t *offset);
+static void res_put_handler(void *request, void *response,
+  uint8_t *buffer, uint16_t preferred_size, int32_t *offset);
+static void res_get_handler1(void *request, void *response, uint8_t *buffer,
+  uint16_t preferred_size, int32_t *offset);
+static void res_post_handler1(void *request, void *response,
+  uint8_t *buffer, uint16_t preferred_size, int32_t *offset);
+static void res_put_handler1(void *request, void *response,
+  uint8_t *buffer, uint16_t preferred_size, int32_t *offset);
+
+
+/*---------------------------------------------------------------------------*/
+/*
+ * Declare the LED resources for the iot-u10.
+ */
+RESOURCE(resource_led,
+  "title=\"LED(default): led=toggle ?len=0..\";rt=\"Text\"",
+  res_get_handler,
+  res_post_handler,
+  res_put_handler,
+  NULL);
+/*---------------------------------------------------------------------------*/
+RESOURCE(resource_led0,
+  "title=\"LED0: led=toggle ?len=0..\";rt=\"Text\"",
+  res_get_handler,
+  res_post_handler,
+  res_put_handler,
+  NULL);
+/*---------------------------------------------------------------------------*/
+RESOURCE(resource_led1,
+  "title=\"LED1: led=toggle ?len=0..\";rt=\"Text\"",
+  res_get_handler1,
+  res_post_handler1,
+  res_put_handler1,
+  NULL);
+/*---------------------------------------------------------------------------*/
+static void
+res_get_handler(void *request, void *response, uint8_t *buffer,
+  uint16_t preferred_size, int32_t *offset)
+{
+  const char *len = NULL;
+  char message[REST_MAX_CHUNK_SIZE];
+  memset(message, 0, REST_MAX_CHUNK_SIZE);
+  if((leds_get() & RESOURCE_LED0) != 0) {
+    sprintf(&message[0], "LED0 ON");
+  } else {
+    sprintf(&message[0], "LED0 OFF");
+  }
+  int length = strlen(&message[0]);
+
+  /* The query string can be retrieved by rest_get_query(),
+   * or parsed for its key-value pairs.
+   */
+  if(REST.get_query_variable(request, "len", &len)) {
+    length = atoi(len);
+    if(length < 0) {
+      length = 0;
+    }
+    if(length > REST_MAX_CHUNK_SIZE) {
+      length = REST_MAX_CHUNK_SIZE;
+    }
+    memcpy(buffer, message, length);
+  } else {
+    memcpy(buffer, message, length);
+  }
+  REST.set_header_content_type(response, REST.type.TEXT_PLAIN);
+  REST.set_header_etag(response, (uint8_t *)&length, 1);
+  REST.set_response_payload(response, buffer, length);
+}
+/*---------------------------------------------------------------------------*/
+static void
+res_post_handler(void *request, void *response, uint8_t *buffer,
+  uint16_t preferred_size, int32_t *offset)
+{
+  int err = 0;
+  char response_message[REST_MAX_CHUNK_SIZE];
+  memset(&response_message[0], 0, REST_MAX_CHUNK_SIZE);
+  uint8_t length = 0;
+  leds_toggle(RESOURCE_LED0);
+  if((leds_get() & RESOURCE_LED0) != 0) {
+    sprintf(&response_message[0], "LED0 Toggle: ON");
+  } else {
+    sprintf(&response_message[0], "LED0 Toggle: OFF");
+  }
+  length = strlen(&response_message[0]);
+
+  if(err) {
+    REST.set_response_status(response, REST.status.BAD_REQUEST);
+  } else {
+    memcpy(buffer, &response_message[0], length);
+  }
+  REST.set_header_content_type(response, REST.type.TEXT_PLAIN);
+  REST.set_header_etag(response, (uint8_t *)&length, 1);
+  REST.set_response_payload(response, buffer, length);
+}
+/*---------------------------------------------------------------------------*/
+static void
+res_put_handler(void *request, void *response, uint8_t *buffer,
+  uint16_t preferred_size, int32_t *offset)
+{
+  size_t len = 0;
+  int err = 0;
+  const char *led = NULL;
+  char response_message[REST_MAX_CHUNK_SIZE];
+  memset(&response_message[0], 0, REST_MAX_CHUNK_SIZE);
+
+  uint8_t length = 0;
+  if((len = coap_get_payload(request, (const uint8_t **)&led))) {
+    if(strncmp(led, "0", len) == 0) {
+      /* Set LED to OFF */
+      leds_off(RESOURCE_LED0);
+      sprintf(&response_message[0], "LED0 OFF");
+      length = strlen(&response_message[0]);
+    } else if(strncmp(led, "1", len) == 0) {
+      /* Set LED to ON */
+      leds_on(RESOURCE_LED0);
+      sprintf(&response_message[0], "LED0 ON");
+      length = strlen(&response_message[0]);
+    } else {
+      /* Unrecognized put request */
+      err++;
+    }
+  }
+  if(err) {
+    REST.set_response_status(response, REST.status.BAD_REQUEST);
+  } else {
+    memcpy(buffer, &response_message[0], length);
+  }
+  REST.set_header_content_type(response, REST.type.TEXT_PLAIN);
+  REST.set_header_etag(response, (uint8_t *)&length, 1);
+  REST.set_response_payload(response, buffer, length);
+}
+/*---------------------------------------------------------------------------*/
+static void
+res_get_handler1(void *request, void *response, uint8_t *buffer,
+  uint16_t preferred_size, int32_t *offset)
+{
+  const char *len = NULL;
+  char message[REST_MAX_CHUNK_SIZE];
+  memset(message, 0, REST_MAX_CHUNK_SIZE);
+  if((leds_get() & RESOURCE_LED1) != 0) {
+    sprintf(&message[0], "LED1 ON");
+  } else {
+    sprintf(&message[0], "LED1 OFF");
+  }
+  int length = strlen(&message[0]);
+
+  /* The query string can be retrieved by rest_get_query(),
+   * or parsed for its key-value pairs.
+   */
+  if(REST.get_query_variable(request, "len", &len)) {
+    length = atoi(len);
+    if(length < 0) {
+      length = 0;
+    }
+    if(length > REST_MAX_CHUNK_SIZE) {
+      length = REST_MAX_CHUNK_SIZE;
+    }
+    memcpy(buffer, message, length);
+  } else {
+    memcpy(buffer, message, length);
+  }
+  REST.set_header_content_type(response, REST.type.TEXT_PLAIN);
+  REST.set_header_etag(response, (uint8_t *)&length, 1);
+  REST.set_response_payload(response, buffer, length);
+}
+/*---------------------------------------------------------------------------*/
+static void
+res_post_handler1(void *request, void *response, uint8_t *buffer,
+  uint16_t preferred_size, int32_t *offset)
+{
+  int err = 0;
+  char response_message[REST_MAX_CHUNK_SIZE];
+  memset(&response_message[0], 0, REST_MAX_CHUNK_SIZE);
+  uint8_t length = 0;
+  leds_toggle(RESOURCE_LED1);
+  if((leds_get() & RESOURCE_LED1) != 0) {
+    sprintf(&response_message[0], "LED1 Toggle: ON");
+  } else {
+    sprintf(&response_message[0], "LED1 Toggle: OFF");
+  }
+  length = strlen(&response_message[0]);
+
+  if(err) {
+    REST.set_response_status(response, REST.status.BAD_REQUEST);
+  } else {
+    memcpy(buffer, &response_message[0], length);
+  }
+  REST.set_header_content_type(response, REST.type.TEXT_PLAIN);
+  REST.set_header_etag(response, (uint8_t *)&length, 1);
+  REST.set_response_payload(response, buffer, length);
+}
+/*---------------------------------------------------------------------------*/
+static void
+res_put_handler1(void *request, void *response, uint8_t *buffer,
+  uint16_t preferred_size, int32_t *offset)
+{
+  size_t len = 0;
+  int err = 0;
+  const char *led = NULL;
+  char response_message[REST_MAX_CHUNK_SIZE];
+  memset(&response_message[0], 0, REST_MAX_CHUNK_SIZE);
+
+  uint8_t length = 0;
+  if((len = coap_get_payload(request, (const uint8_t **)&led))) {
+    if(strncmp(led, "0", len) == 0) {
+      /* Set LED to OFF */
+      leds_off(RESOURCE_LED1);
+      sprintf(&response_message[0], "LED1 OFF");
+      length = strlen(&response_message[0]);
+    } else if(strncmp(led, "1", len) == 0) {
+      /* Set LED to ON */
+      leds_on(RESOURCE_LED1);
+      sprintf(&response_message[0], "LED1 ON");
+      length = strlen(&response_message[0]);
+    } else {
+      /* Unrecognized put request */
+      err++;
+    }
+  }
+  if(err) {
+    REST.set_response_status(response, REST.status.BAD_REQUEST);
+  } else {
+    memcpy(buffer, &response_message[0], length);
+  }
+  REST.set_header_content_type(response, REST.type.TEXT_PLAIN);
+  REST.set_header_etag(response, (uint8_t *)&length, 1);
+  REST.set_response_payload(response, buffer, length);
+}
+/*---------------------------------------------------------------------------*/

--- a/apps/mote-res/resources-coap/resource-rpl-info.c
+++ b/apps/mote-res/resources-coap/resource-rpl-info.c
@@ -1,0 +1,225 @@
+/* Copyright (c) 2015, Yanzi Networks AB.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holders nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ * USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ */
+
+#include "resources-coap.h"
+#include "contiki-net.h"
+#include "rest-engine.h"
+#include "rpl.h"
+#include "rpl-private.h"
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+
+
+static void res_rpl_info_get_handler(void *request, void *response, uint8_t *buffer,
+  uint16_t preferred_size, int32_t *offset);
+static void res_rpl_parent_get_handler(void *request, void *response,
+  uint8_t *buffer, uint16_t preferred_size, int32_t *offset);
+static void res_rpl_rank_get_handler(void *request, void *response,
+  uint8_t *buffer, uint16_t preferred_size, int32_t *offset);
+static void res_rpl_link_metric_get_handler(void *request, void *response,
+  uint8_t *buffer, uint16_t preferred_size, int32_t *offset);
+
+/*---------------------------------------------------------------------------*/
+RESOURCE(resource_rpl_info,
+  "title=\"RPL Information\";obs",
+  res_rpl_info_get_handler,
+  NULL,
+  NULL,
+  NULL);
+/*---------------------------------------------------------------------------*/
+RESOURCE(resource_rpl_parent,
+  "title=\"RPL Parent\";obs",
+  res_rpl_parent_get_handler,
+  NULL,
+  NULL,
+  NULL);
+/*---------------------------------------------------------------------------*/
+RESOURCE(resource_rpl_rank,
+  "title=\"RPL Rank\";obs",
+  res_rpl_rank_get_handler,
+  NULL,
+  NULL,
+  NULL);
+/*---------------------------------------------------------------------------*/
+RESOURCE(resource_rpl_link_metric,
+  "title=\"RPL Link Metric\";obs",
+  res_rpl_link_metric_get_handler,
+  NULL,
+  NULL,
+  NULL);
+/*---------------------------------------------------------------------------*/
+static void res_rpl_parent_get_handler(void *request, void *response,
+  uint8_t *buffer, uint16_t preferred_size, int32_t *offset)
+{
+  uint16_t length;
+  rpl_instance_t *instance;
+  char message[REST_MAX_CHUNK_SIZE];
+
+  memset(message, 0, REST_MAX_CHUNK_SIZE);
+  instance = rpl_get_instance(RPL_DEFAULT_INSTANCE);
+  /* Print the parent */
+  if(instance != NULL &&
+    instance->current_dag != NULL &&
+    instance->current_dag->preferred_parent != NULL) {
+    sprintf(&message[0], "RPL Parent: ");
+    sprint_addr6(&message[0],
+      rpl_get_parent_ipaddr(instance->current_dag->preferred_parent));
+  } else {
+    sprintf(&message[0], "No parent yet\n");
+  }
+  length = strlen(&message[0]);
+  memcpy(buffer, message, length);
+
+  REST.set_header_content_type(response, REST.type.TEXT_PLAIN);
+  REST.set_header_etag(response, (uint8_t *)&length, 1);
+  REST.set_response_payload(response, buffer, length);
+}
+/*---------------------------------------------------------------------------*/
+static void res_rpl_rank_get_handler(void *request, void *response,
+  uint8_t *buffer, uint16_t preferred_size, int32_t *offset)
+{
+  uint16_t length;
+  rpl_instance_t *instance;
+  char message[REST_MAX_CHUNK_SIZE];
+
+  memset(message, 0, REST_MAX_CHUNK_SIZE);
+  instance = rpl_get_instance(RPL_DEFAULT_INSTANCE);
+  /* Print the RPL rank */
+  if(instance != NULL && instance->current_dag != NULL) {
+    snprintf(message, sizeof(message) - 1, "RPL Rank: %u.%02u",
+            instance->current_dag->rank / RPL_DAG_MC_ETX_DIVISOR,
+            (100 * (instance->current_dag->rank % RPL_DAG_MC_ETX_DIVISOR)) / RPL_DAG_MC_ETX_DIVISOR);
+  } else {
+    snprintf(message, sizeof(message) - 1, "No rank yet");
+  }
+  length = strlen(&message[0]);
+  memcpy(buffer, message, length);
+
+  REST.set_header_content_type(response, REST.type.TEXT_PLAIN);
+  REST.set_header_etag(response, (uint8_t *)&length, 1);
+  REST.set_response_payload(response, buffer, length);
+}
+/*---------------------------------------------------------------------------*/
+static void res_rpl_link_metric_get_handler(void *request, void *response,
+  uint8_t *buffer, uint16_t preferred_size, int32_t *offset)
+{
+  uint16_t length;
+  rpl_instance_t *instance;
+  uip_ds6_nbr_t *nbr;
+  char message[REST_MAX_CHUNK_SIZE];
+
+  memset(message, 0, REST_MAX_CHUNK_SIZE);
+  instance = rpl_get_instance(RPL_DEFAULT_INSTANCE);
+  /* Print the link metric to parent */
+  if(instance != NULL &&
+    instance->current_dag != NULL &&
+    instance->current_dag->preferred_parent != NULL &&
+     (nbr = rpl_get_nbr(instance->current_dag->preferred_parent)) != NULL) {
+    snprintf(message, sizeof(message) - 1, "Link Metric: %u.%02u\n",
+             nbr->link_metric / RPL_DAG_MC_ETX_DIVISOR,
+             (100 * (nbr->link_metric % RPL_DAG_MC_ETX_DIVISOR)) / RPL_DAG_MC_ETX_DIVISOR);
+  } else {
+    snprintf(message, sizeof(message) - 1, "No link metric yet\n");
+  }
+  length = strlen(message);
+  memcpy(buffer, message, length);
+
+  REST.set_header_content_type(response, REST.type.TEXT_PLAIN);
+  REST.set_header_etag(response, (uint8_t *)&length, 1);
+  REST.set_response_payload(response, buffer, length);
+}
+/*---------------------------------------------------------------------------*/
+static void
+res_rpl_info_get_handler(void *request, void *response, uint8_t *buffer,
+  uint16_t preferred_size, int32_t *offset)
+{
+  /*Return RPL information in JSON format */
+  uint16_t length = 0;
+  rpl_instance_t *instance;
+  uip_ds6_nbr_t *nbr;
+  char message[REST_MAX_CHUNK_SIZE];
+  memset(message, 0, sizeof(message));
+
+  instance = rpl_get_instance(RPL_DEFAULT_INSTANCE);
+  if(instance != NULL &&
+     instance->current_dag != NULL &&
+     instance->current_dag->preferred_parent != NULL) {
+    nbr = rpl_get_nbr(instance->current_dag->preferred_parent);
+  } else {
+    nbr = NULL;
+  }
+
+  /* Write all RPL info in JSON format */
+  snprintf(message, sizeof(message) - 1, "{\"parent\":\"");
+  length = strlen(message);
+
+  if(instance != NULL &&
+    instance->current_dag != NULL &&
+    instance->current_dag->preferred_parent != NULL) {
+    sprint_addr6(&message[length],
+                 rpl_get_parent_ipaddr(instance->current_dag->preferred_parent));
+    length = strlen(message);
+    snprintf(&message[length], sizeof(message) - length - 1, "\"");
+  } else {
+    snprintf(&message[length], sizeof(message) - length - 1, "None\"");
+  }
+  length = strlen(message);
+
+  snprintf(&message[length], sizeof(message) - length - 1, " ,\"rank\":\"");
+  length = strlen(message);
+
+  if(instance != NULL && instance->current_dag != NULL) {
+    snprintf(&message[length], sizeof(message) - length - 1, "%u.%02u\"",
+             (instance->current_dag->rank / RPL_DAG_MC_ETX_DIVISOR),
+             (100 * (instance->current_dag->rank % RPL_DAG_MC_ETX_DIVISOR)) / RPL_DAG_MC_ETX_DIVISOR);
+  } else {
+    snprintf(&message[length], sizeof(message) - length - 1, "inf\"");
+  }
+  length = strlen(message);
+
+  snprintf(&message[length], sizeof(message) - length - 1, " ,\"link-metric\":\"");
+  length = strlen(message);
+  if(nbr != NULL) {
+    snprintf(&message[length], sizeof(message) - length - 1, "%u.%02u\"",
+             nbr->link_metric / RPL_DAG_MC_ETX_DIVISOR,
+             (100 * (nbr->link_metric % RPL_DAG_MC_ETX_DIVISOR)) / RPL_DAG_MC_ETX_DIVISOR);
+  } else {
+    snprintf(&message[length], sizeof(message) - length - 1, "inf\"");
+  }
+  length = strlen(message);
+  snprintf(&message[length], sizeof(message) - length - 1, "}");
+  length = strlen(message);
+  memcpy(buffer, message, length);
+
+  REST.set_header_content_type(response, REST.type.APPLICATION_JSON);
+  REST.set_header_etag(response, (uint8_t *)&length, 1);
+  REST.set_response_payload(response, buffer, length);
+}
+/*---------------------------------------------------------------------------*/

--- a/apps/mote-res/resources-coap/resource-temperature.c
+++ b/apps/mote-res/resources-coap/resource-temperature.c
@@ -1,0 +1,102 @@
+/* Copyright (c) 2015, Yanzi Networks AB.
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holders nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ * USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ */
+
+#include "resources-coap.h"
+#include "contiki-net.h"
+#include "rest-engine.h"
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#if PLATFORM_HAS_SENSORS
+#include "stts751.h"
+#endif
+
+static void res_get_handler(void *request, void *response, uint8_t *buffer,
+  uint16_t preferred_size, int32_t *offset);
+
+/*---------------------------------------------------------------------------*/
+static uint16_t
+print_temperature(char *msg)
+{
+#if PLATFORM_HAS_SENSORS
+  uint32_t millikelvin = stts751_millikelvin();
+  int32_t celcius_int_part = millikelvin/1000-273;
+  uint8_t celcius_dec_part = (millikelvin/100) - (millikelvin/1000)*10;
+  sprintf(msg+strlen(msg),"Temperature (C): %2ld.%u",
+    celcius_int_part, celcius_dec_part);
+#else
+  sprintf(msg+strlen(msg),"Temperature (C): %2ld.%u",
+    0, 0);
+#endif
+
+  return strlen(msg);
+}
+/*---------------------------------------------------------------------------*/
+/*
+ * Declare the IPv6 neighbors resource 
+ */
+RESOURCE(resource_temperature,
+  "title=\"Temperature: ?len=0..\";rt=\"Text\"",
+  res_get_handler,
+  NULL,
+  NULL,
+  NULL);
+/*---------------------------------------------------------------------------*/
+static void
+res_get_handler(void *request, void *response, uint8_t *buffer,
+  uint16_t preferred_size, int32_t *offset)
+{
+  const char *len = NULL;
+  char message[40];
+  memset(message, 0, 40);
+  print_temperature(&message[0]);
+  
+  int length = strlen(&message[0]);
+
+  /* The query string can be retrieved by rest_get_query(),
+   * or parsed for its key-value pairs.
+   */
+  if(REST.get_query_variable(request, "len", &len)) {
+    length = atoi(len);
+    if(length < 0) {
+      length = 0;
+    }
+    if(length > REST_MAX_CHUNK_SIZE) {
+      length = REST_MAX_CHUNK_SIZE;
+    }
+    memcpy(buffer, message, length);
+  } else {
+    memcpy(buffer, message, length);
+  }
+  REST.set_header_content_type(response, REST.type.TEXT_PLAIN);
+  REST.set_header_etag(response, (uint8_t *)&length, 1);
+  REST.set_response_payload(response, buffer, length);
+}
+/*---------------------------------------------------------------------------*/
+

--- a/apps/mote-res/resources-coap/resources-coap.h
+++ b/apps/mote-res/resources-coap/resources-coap.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2016, Yanzi Networks AB.
+ * Copyright (c) 2015, Yanzi Networks AB.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -25,28 +25,26 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
  * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
+ *
  */
 
-#ifndef PROJECT_CONF_H_
-#define PROJECT_CONF_H_
+#ifndef RESOURCES_COAP_COMMON_H_
+#define RESOURCES_COAP_COMMON_H_
 
-#define USB_SERIAL_CONF_ENABLE 1
-#define DBG_CONF_USB 1
+#include "rest-engine.h"
+#include "resource-print-engine.h"
+#include "net/ip/uip.h"
 
-#define PRODUCT_TYPE_INT64 0x0090DA0301010501ULL
-#define PRODUCT_LABEL "IoT-U10"
+extern resource_t resource_led, \
+                  resource_led0, \
+                  resource_led1, \
+                  resource_ipv6_neighbors, \
+                  resource_ipv6_routes, \
+                  resource_push_button_event, \
+                  resource_temperature, \
+                  resource_rpl_info, \
+                  resource_rpl_parent, \
+                  resource_rpl_rank, \
+                  resource_rpl_link_metric;
 
-/* Network statistics */
-#define RPL_CONF_STATS 1
-/* #define HANDLER_802154_CONF_STATS 1 */
-
-/* #define RPL_CALLBACK_PARENT_SWITCH \ */
-/*   instance_nstats_preferred_parent_callback */
-
-/* CoAP */
-#undef REST_MAX_CHUNK_SIZE
-#define REST_MAX_CHUNK_SIZE 256
-
-#define WEBSERVER_CONF_CFS_PATHLEN 24
-
-#endif /* PROJECT_CONF_H_ */
+#endif /* RESOURCES_COAP_COMMON_H_ */

--- a/apps/mote-res/resources-common/Makefile.resources-common
+++ b/apps/mote-res/resources-common/Makefile.resources-common
@@ -1,0 +1,5 @@
+ifdef COAP_NO_SENSORS
+  resources-common_src = resource-print-engine.c print-rpl-info.c
+else
+  resources-common_src = resource-print-engine.c print-temperature.c print-rpl-info.c
+endif

--- a/apps/mote-res/resources-common/print-rpl-info.c
+++ b/apps/mote-res/resources-common/print-rpl-info.c
@@ -1,0 +1,88 @@
+/* Copyright (c) 2015, Yanzi Networks AB.
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holders nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ * USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ */
+
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "resource-print-engine.h"
+#include "rpl.h"
+#include "rpl-private.h"
+/*---------------------------------------------------------------------------*/
+uint16_t
+print_rpl_parent(char *msg, int max_chars)
+{
+  rpl_instance_t *instance;
+  instance = rpl_get_instance(RPL_DEFAULT_INSTANCE);
+  if(instance != NULL &&
+    instance->current_dag != NULL &&
+    instance->current_dag->preferred_parent != NULL) {
+    sprint_addr6(msg,
+      rpl_get_parent_ipaddr(instance->current_dag->preferred_parent));
+  } else {
+    snprintf(msg, max_chars, "Null");
+  }
+  return strlen(msg);
+}
+/*---------------------------------------------------------------------------*/
+uint16_t
+print_rpl_rank(char *msg, int max_chars)
+{
+  rpl_instance_t *instance;
+  instance = rpl_get_instance(RPL_DEFAULT_INSTANCE);
+  if(instance != NULL && instance->current_dag != NULL) {
+    snprintf(msg, max_chars, "%u.%02u", 
+      instance->current_dag->rank / RPL_DAG_MC_ETX_DIVISOR,
+      (100 * instance->current_dag->rank % RPL_DAG_MC_ETX_DIVISOR) /
+      RPL_DAG_MC_ETX_DIVISOR);
+  } else {
+    snprintf(msg, max_chars, "inf");
+  }
+  return strlen(msg);
+}
+/*---------------------------------------------------------------------------*/
+uint16_t
+print_rpl_link_metric(char *msg, int max_chars)
+{
+  rpl_instance_t *instance;
+  uip_ds6_nbr_t *nbr;
+  instance = rpl_get_instance(RPL_DEFAULT_INSTANCE);
+  if(instance != NULL &&
+    instance->current_dag != NULL &&
+    instance->current_dag->preferred_parent != NULL &&
+    (nbr = rpl_get_nbr(instance->current_dag->preferred_parent)) != NULL) {
+    snprintf(msg, max_chars, "%u.%02u\n",
+      nbr->link_metric / RPL_DAG_MC_ETX_DIVISOR,
+      (100 * (nbr->link_metric % RPL_DAG_MC_ETX_DIVISOR)) /
+      RPL_DAG_MC_ETX_DIVISOR);
+  } else {
+    snprintf(msg, max_chars, "inf");
+  }
+  return strlen(msg);
+}
+/*---------------------------------------------------------------------------*/

--- a/apps/mote-res/resources-common/print-rpl-info.h
+++ b/apps/mote-res/resources-common/print-rpl-info.h
@@ -1,7 +1,6 @@
-/*
- * Copyright (c) 2015-2016, Yanzi Networks AB.
+/* Copyright (c) 2015, Yanzi Networks AB.
  * All rights reserved.
- *
+ * 
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *    1. Redistributions of source code must retain the above copyright
@@ -25,28 +24,11 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
  * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
+ *
  */
 
-#ifndef PROJECT_CONF_H_
-#define PROJECT_CONF_H_
 
-#define USB_SERIAL_CONF_ENABLE 1
-#define DBG_CONF_USB 1
+uint16_t print_rpl_parent(char *msg, int max_chars);
+uint16_t print_rpl_rank(char * msg, int max_chars);
+uint16_t print_rpl_link_metric(char *msg, int max_chars);
 
-#define PRODUCT_TYPE_INT64 0x0090DA0301010501ULL
-#define PRODUCT_LABEL "IoT-U10"
-
-/* Network statistics */
-#define RPL_CONF_STATS 1
-/* #define HANDLER_802154_CONF_STATS 1 */
-
-/* #define RPL_CALLBACK_PARENT_SWITCH \ */
-/*   instance_nstats_preferred_parent_callback */
-
-/* CoAP */
-#undef REST_MAX_CHUNK_SIZE
-#define REST_MAX_CHUNK_SIZE 256
-
-#define WEBSERVER_CONF_CFS_PATHLEN 24
-
-#endif /* PROJECT_CONF_H_ */

--- a/apps/mote-res/resources-common/print-temperature.c
+++ b/apps/mote-res/resources-common/print-temperature.c
@@ -1,7 +1,6 @@
-/*
- * Copyright (c) 2015-2016, Yanzi Networks AB.
+/* Copyright (c) 2015, Yanzi Networks AB.
  * All rights reserved.
- *
+ * 
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *    1. Redistributions of source code must retain the above copyright
@@ -25,28 +24,32 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
  * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
+ *
  */
 
-#ifndef PROJECT_CONF_H_
-#define PROJECT_CONF_H_
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#if PLATFORM_HAS_SENSORS
+#include "stts751.h"
+#else
+#include "contiki-conf.h"
+#endif
 
-#define USB_SERIAL_CONF_ENABLE 1
-#define DBG_CONF_USB 1
-
-#define PRODUCT_TYPE_INT64 0x0090DA0301010501ULL
-#define PRODUCT_LABEL "IoT-U10"
-
-/* Network statistics */
-#define RPL_CONF_STATS 1
-/* #define HANDLER_802154_CONF_STATS 1 */
-
-/* #define RPL_CALLBACK_PARENT_SWITCH \ */
-/*   instance_nstats_preferred_parent_callback */
-
-/* CoAP */
-#undef REST_MAX_CHUNK_SIZE
-#define REST_MAX_CHUNK_SIZE 256
-
-#define WEBSERVER_CONF_CFS_PATHLEN 24
-
-#endif /* PROJECT_CONF_H_ */
+/*---------------------------------------------------------------------------*/
+uint16_t
+print_temperature(char *msg, int max_chars)
+{
+#if PLATFORM_HAS_SENSORS
+  uint32_t millikelvin = stts751_millikelvin();
+  int32_t celcius_int_part = millikelvin/1000-273;
+  uint8_t celcius_dec_part = (millikelvin/100) - (millikelvin/1000)*10;
+  snprintf(msg+strlen(msg), max_chars, "Temperature (C): %2ld.%u",
+    celcius_int_part, celcius_dec_part);
+#else
+  sprintf(msg+strlen(msg),"Temperature (C): %2ld.%u",
+    0, 0);
+#endif
+  return strlen(msg);
+}
+/*---------------------------------------------------------------------------*/

--- a/apps/mote-res/resources-common/print-temperature.h
+++ b/apps/mote-res/resources-common/print-temperature.h
@@ -1,7 +1,6 @@
-/*
- * Copyright (c) 2015-2016, Yanzi Networks AB.
+/* Copyright (c) 2015, Yanzi Networks AB.
  * All rights reserved.
- *
+ * 
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *    1. Redistributions of source code must retain the above copyright
@@ -12,7 +11,7 @@
  *    3. Neither the name of the copyright holders nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- *
+ * 
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
  * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
@@ -25,28 +24,9 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
  * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
+ *
  */
 
-#ifndef PROJECT_CONF_H_
-#define PROJECT_CONF_H_
 
-#define USB_SERIAL_CONF_ENABLE 1
-#define DBG_CONF_USB 1
+uint16_t print_temperature(char *msg, int max_chars);
 
-#define PRODUCT_TYPE_INT64 0x0090DA0301010501ULL
-#define PRODUCT_LABEL "IoT-U10"
-
-/* Network statistics */
-#define RPL_CONF_STATS 1
-/* #define HANDLER_802154_CONF_STATS 1 */
-
-/* #define RPL_CALLBACK_PARENT_SWITCH \ */
-/*   instance_nstats_preferred_parent_callback */
-
-/* CoAP */
-#undef REST_MAX_CHUNK_SIZE
-#define REST_MAX_CHUNK_SIZE 256
-
-#define WEBSERVER_CONF_CFS_PATHLEN 24
-
-#endif /* PROJECT_CONF_H_ */

--- a/apps/mote-res/resources-common/resource-print-engine.c
+++ b/apps/mote-res/resources-common/resource-print-engine.c
@@ -1,5 +1,4 @@
-/*
- * Copyright (c) 2015-2016, Yanzi Networks AB.
+/* Copyright (c) 2014, Ioannis Glaropoulos
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -13,6 +12,7 @@
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
  *
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
  * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
@@ -25,28 +25,50 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
  * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
+ *
  */
-
-#ifndef PROJECT_CONF_H_
-#define PROJECT_CONF_H_
-
-#define USB_SERIAL_CONF_ENABLE 1
-#define DBG_CONF_USB 1
-
-#define PRODUCT_TYPE_INT64 0x0090DA0301010501ULL
-#define PRODUCT_LABEL "IoT-U10"
-
-/* Network statistics */
-#define RPL_CONF_STATS 1
-/* #define HANDLER_802154_CONF_STATS 1 */
-
-/* #define RPL_CALLBACK_PARENT_SWITCH \ */
-/*   instance_nstats_preferred_parent_callback */
-
-/* CoAP */
-#undef REST_MAX_CHUNK_SIZE
-#define REST_MAX_CHUNK_SIZE 256
-
-#define WEBSERVER_CONF_CFS_PATHLEN 24
-
-#endif /* PROJECT_CONF_H_ */
+#include <stdio.h>
+#define DEBUG 0
+#if DEBUG
+#define PRINTF(...) printf(__VA_ARGS__)
+#define SPRINT6ADDR(addr) sprint_addr6(buf, addr)
+#else
+#define PRINTF(...)
+#define SPRINT6ADDR(addr)
+#endif
+#include "resource-print-engine.h"
+/*---------------------------------------------------------------------------*/
+int
+sprint_addr6(char *buf, const uip_ipaddr_t *addr)
+{
+  if(addr == NULL || addr->u8 == NULL) {
+    PRINTF("(NULL IP addr)");
+    return 0;
+  }
+  uint16_t a;
+  unsigned int i;
+  int f;
+  uint16_t start_offset = strlen(buf);
+  uint16_t offset;
+  int len = 0;
+  for(i = 0, f = 0; i < sizeof(uip_ipaddr_t); i += 2) {
+    a = (addr->u8[i] << 8) + addr->u8[i + 1];
+    if(a == 0 && f >= 0) {
+      if(f++ == 0) {
+	offset = start_offset + len;
+        len += sprintf(buf+offset, "::");
+      }
+    } else {
+      if(f > 0) {
+        f = -1;
+      } else if(i > 0) {
+	offset = start_offset + len;
+        len += sprintf(buf+offset, ":");
+      }
+      offset = start_offset + len;
+      len += sprintf(buf+offset, "%x", a);
+    }
+  }
+  return len;
+}
+/*---------------------------------------------------------------------------*/

--- a/apps/mote-res/resources-common/resource-print-engine.h
+++ b/apps/mote-res/resources-common/resource-print-engine.h
@@ -1,7 +1,6 @@
-/*
- * Copyright (c) 2015-2016, Yanzi Networks AB.
+/* Copyright (c) 2015, Yanzi Networks AB.
  * All rights reserved.
- *
+ * 
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *    1. Redistributions of source code must retain the above copyright
@@ -25,28 +24,9 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
  * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
+ *
  */
 
-#ifndef PROJECT_CONF_H_
-#define PROJECT_CONF_H_
+#include "net/ip/uip.h"
 
-#define USB_SERIAL_CONF_ENABLE 1
-#define DBG_CONF_USB 1
-
-#define PRODUCT_TYPE_INT64 0x0090DA0301010501ULL
-#define PRODUCT_LABEL "IoT-U10"
-
-/* Network statistics */
-#define RPL_CONF_STATS 1
-/* #define HANDLER_802154_CONF_STATS 1 */
-
-/* #define RPL_CALLBACK_PARENT_SWITCH \ */
-/*   instance_nstats_preferred_parent_callback */
-
-/* CoAP */
-#undef REST_MAX_CHUNK_SIZE
-#define REST_MAX_CHUNK_SIZE 256
-
-#define WEBSERVER_CONF_CFS_PATHLEN 24
-
-#endif /* PROJECT_CONF_H_ */
+int sprint_addr6(char *buf, const uip_ipaddr_t *addr);

--- a/apps/mote-res/resources-web/Makefile.resources-web
+++ b/apps/mote-res/resources-web/Makefile.resources-web
@@ -1,0 +1,7 @@
+resources-web_src += node-webserver-simple.c
+CFLAGS += -DWITH_WEBSERVER=1
+
+# Include the httpd implementation in the build tree and search path
+CONTIKI_SOURCEFILES += httpd-simple.c
+CONTIKIDIRS +=  $(CONTIKI)/examples/ipv6/rpl-border-router
+

--- a/apps/mote-res/resources-web/node-webserver-simple.c
+++ b/apps/mote-res/resources-web/node-webserver-simple.c
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2010, Swedish Institute of Computer Science.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ */
+
+/**
+ * \file
+ *         A simple web server used to retrieve RPL data
+ *         from a mote.
+ * \author
+ *         Niclas Finne    <nfi@sics.se>
+ *         Joakim Eriksson <joakime@sics.se>
+ *         Joel Hoglund    <joel@sics.se>
+ */
+
+#include "contiki.h"
+#include "httpd-simple.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "print-rpl-info.h"
+#include "resource-print-engine.h"
+
+#define SIMPLE_HTML_BODY_LEN 400
+
+PROCESS(node_webserver_simple_process, "Node Simple Web server");
+
+/*
+ * Node Simple Webserver process 
+ */
+PROCESS_THREAD(node_webserver_simple_process, ev, data)
+{
+  PROCESS_BEGIN();
+
+  httpd_init();
+
+  while(1) {
+    PROCESS_WAIT_EVENT_UNTIL(ev == tcpip_event);
+    httpd_appcall(data);
+  }
+
+  PROCESS_END();
+}
+/*---------------------------------------------------------------------------*/
+static const char *TOP = "<html><head><title>Node Web Server</title></head><body>\n";
+static const char *BOTTOM = "</body></html>\n";
+/*---------------------------------------------------------------------------*/
+static char buf[SIMPLE_HTML_BODY_LEN];
+static int blen;
+#define ADD(...) do {                                                    \
+    if(sizeof(buf) -1 > blen) {                                          \
+      blen += snprintf(&buf[blen], sizeof(buf) - blen - 1, __VA_ARGS__); \
+    }                                                                    \
+  } while(0)
+
+/*---------------------------------------------------------------------------*/
+static
+PT_THREAD(send_web_response(struct httpd_state *s))
+{
+  PSOCK_BEGIN(&s->sout);
+
+  SEND_STRING(&s->sout, TOP);
+
+  memset(buf, 0, SIMPLE_HTML_BODY_LEN);
+  blen = 0;
+
+  if((strcmp(s->filename, "/index") == 0) ||
+    (strcmp(s->filename, "/index.html") == 0) ||
+    (s->filename[1] == '\0')) {
+    /* Index or empty page: display the pages to read from the mote */
+    ADD("<h1>Mote Info</h1>"
+        "<a href=\"");
+    ADD("rpl-info\">RPL info</a>"
+        "<ol>"
+        "<li> <a href=\"");    
+    ADD("rpl-info/parent\">parent</a>"
+        "</li>"
+        "<li> <a href=\"");
+    ADD("rpl-info/rank\">rank</a>"
+        "</li>"
+        "<li> <a href=\"");
+    ADD("rpl-info/link-m\">link-metric</a>"
+        "</li>"
+        "</ol>");
+    SEND_STRING(&s->sout, buf);
+  } else if(strcmp(s->filename, "/rpl-info/parent") == 0) {
+    ADD("<h1>RPL Parent: ");
+    blen += print_rpl_parent(&buf[blen], SIMPLE_HTML_BODY_LEN - blen - 1);
+    SEND_STRING(&s->sout, buf);
+  } else if(strcmp(s->filename, "/rpl-info/rank") == 0) {
+    ADD("<h1>RPL Rank: ");
+    blen += print_rpl_rank(&buf[blen], SIMPLE_HTML_BODY_LEN - blen - 1);
+    SEND_STRING(&s->sout, buf);
+  } else if(strcmp(s->filename, "/rpl-info/link-m") == 0) {
+    ADD("<h1>Link-metric: ");
+    blen += print_rpl_link_metric(&buf[blen], SIMPLE_HTML_BODY_LEN - blen - 1);
+    SEND_STRING(&s->sout, buf);
+  } else if(strcmp(s->filename, "/rpl-info") == 0) {
+    ADD("<h1>RPL Info</h1>"
+        "Parent: ");
+    blen += print_rpl_parent(&buf[blen], SIMPLE_HTML_BODY_LEN - blen - 1);
+    ADD("<br>");
+    ADD("Rank: ");
+    blen += print_rpl_rank(&buf[blen], SIMPLE_HTML_BODY_LEN - blen - 1);
+    ADD("<br>");
+    ADD("Link-metric: ");
+    blen += print_rpl_link_metric(&buf[blen], SIMPLE_HTML_BODY_LEN - blen - 1);
+    SEND_STRING(&s->sout, buf);
+  } else {
+    ADD("<h1>Page not found</h1>");
+    SEND_STRING(&s->sout, buf);
+  }
+  SEND_STRING(&s->sout, BOTTOM);
+  blen = 0;
+  PSOCK_END(&s->sout);
+}
+/*---------------------------------------------------------------------------*/
+httpd_simple_script_t
+httpd_simple_get_script(const char *name)
+{
+  return send_web_response;
+}
+/*---------------------------------------------------------------------------*/

--- a/apps/mote-res/resources-web/node-webserver-simple.h
+++ b/apps/mote-res/resources-web/node-webserver-simple.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2010, Swedish Institute of Computer Science.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ */
+
+#include "contiki.h"
+#include "process.h"
+
+
+PROCESS_NAME(node_webserver_simple_process);

--- a/apps/sparrow-instances/instance-flash/instance-flash.c
+++ b/apps/sparrow-instances/instance-flash/instance-flash.c
@@ -89,6 +89,7 @@ flash_process_request(const sparrow_oam_instance_t *instance,
   const image_info_t *images;
   const image_info_t *image = NULL;
   uint8_t *write_enable;
+  uint8_t image_index = 0;
 
   images = image_trailer_get_images();
 
@@ -101,10 +102,12 @@ flash_process_request(const sparrow_oam_instance_t *instance,
     /* PRIMARY_FLASH_INSTANCE */
     image = &images[0];
     write_enable = &primaryWrite_enable;
+    image_index = 1;
   } else if(instance == &instance_flash_backup) {
     /* BACKUP_FLASH_INSTANCE */
     image = &images[1];
     write_enable = &backupWrite_enable;
+    image_index = 2;
   } else {
     return sparrow_tlv_write_reply_error(request, SPARROW_TLV_ERROR_UNKNOWN_INSTANCE, reply, len);
   }
@@ -126,7 +129,7 @@ flash_process_request(const sparrow_oam_instance_t *instance,
         return sparrow_tlv_write_reply_error(request, error, reply, len);
       }
     } else if(request->variable == VARIABLE_WRITE_CONTROL) {
-      if(request->instance == SPARROW_DEVICE.get_running_image()) {
+      if(!image_index || image_index == SPARROW_DEVICE.get_running_image()) {
         return sparrow_tlv_write_reply_error(request, SPARROW_TLV_ERROR_WRITE_ACCESS_DENIED, reply, len);
       }
       local32 = request->data[0] << 24;

--- a/cpu/cc253x/usb/common/usb-core.c
+++ b/cpu/cc253x/usb/common/usb-core.c
@@ -38,6 +38,14 @@ static unsigned char usb_flags = 0;
 static struct process *global_user_event_pocess = NULL;
 static unsigned int global_user_events = 0;
 
+static uint8_t usb_attached = 0;
+
+uint8_t 
+is_usb_attached(void)
+{
+  return usb_attached;
+}
+
 void
 usb_set_global_event_process(struct process *p)
 {
@@ -536,6 +544,7 @@ PROCESS_THREAD(usb_process, ev, data)
                 while(usb_send_pending(0));
                 usb_arch_set_address(LOW_BYTE(usb_setup_buffer.wValue));
                 usb_flags &= ~USB_FLAG_ADDRESS_PENDING;
+                usb_attached = 1;
               }
               submit_setup();
             } else if(ctrl_buffer.id == OUT_ID) {

--- a/examples/felicia/iot-u10/Makefile
+++ b/examples/felicia/iot-u10/Makefile
@@ -16,5 +16,9 @@ APPS += sparrow-instances/instance-leds
 APPS += sparrow-instances/instance-button
 APPS += sparrow-instances/instance-nstats
 
+ifdef WITH_NETSCAN
+APPS += netscan
+endif
+
 CONTIKI_WITH_IPV6 = 1
 include $(SPARROW)/Makefile.sparrow

--- a/examples/felicia/iot-u10/Makefile
+++ b/examples/felicia/iot-u10/Makefile
@@ -15,9 +15,17 @@ APPS += sparrow-instances/stts751
 APPS += sparrow-instances/instance-leds
 APPS += sparrow-instances/instance-button
 APPS += sparrow-instances/instance-nstats
+APPS += er-coap
+APPS += rest-engine
+APPS += mote-res/resources-coap
+APPS += mote-res/resources-common
 
 ifdef WITH_NETSCAN
 APPS += netscan
+endif
+
+ifdef WITH_WEBSERVER
+APPS += mote-res/resources-web
 endif
 
 CONTIKI_WITH_IPV6 = 1

--- a/examples/sparrow/wsptlvs.py
+++ b/examples/sparrow/wsptlvs.py
@@ -55,10 +55,10 @@ def tlvled(ws, ip, led):
         t1 = tlvlib.create_set_tlv32(de.leds_instance, tlvlib.VARIABLE_LED_TOGGLE, 1 << int(led))
         try:
             enc, tlvs = tlvlib.send_tlv(t1, ip)
-            if tlvs[0].Error == 0:
+            if tlvs[0].error == 0:
                 print "LED ", led, " toggle."
             else:
-                print "LED Set error", tlvs[0].Error
+                print "LED Set error", tlvs[0].error
         except socket.timeout:
             print "LED No response from node", ip
             ws.sendMessage(json.dumps({"error":"No response from node " + ip}))
@@ -72,14 +72,14 @@ def tlvtemp(ws, ip):
             t1 = tlvlib.create_get_tlv32(instance, tlvlib.VARIABLE_TEMPERATURE)
             try:
                 enc, tlvs = tlvlib.send_tlv(t1, ip)
-                if tlvs[0].Error == 0:
+                if tlvs[0].error == 0:
                     temperature = tlvs[0].int_value
                     if temperature > 100000:
                         temperature = round((temperature - 273150) / 1000.0, 2)
                     print "\tTemperature:",temperature,"(C)"
                     ws.sendMessage(json.dumps({"temp":temperature,"address":ip}))
                 else:
-                    print "\tTemperature error", tlvs[0].Error
+                    print "\tTemperature error", tlvs[0].error
             except socket.timeout:
                 print "Temperature - no response from node", ip
                 ws.sendMessage(json.dumps({"error":"No response from node " + ip}))

--- a/platform/felicia/felicia/board.h
+++ b/platform/felicia/felicia/board.h
@@ -49,10 +49,10 @@
 #include "dev/gpio.h"
 #include "dev/nvic.h"
 
-#define PLATFORM_HAS_LEDS    1
-#define PLATFORM_HAS_BUTTON  1
+#define PLATFORM_HAS_LEDS    0
+#define PLATFORM_HAS_BUTTON  0
 #define PLATFORM_HAS_SLIDE_SWITCH 0
-#define PLATFORM_HAS_SENSORS 1
+#define PLATFORM_HAS_SENSORS 0
 
 #define LEDS_YELLOW          1
 #define LEDS_GREEN           2
@@ -63,12 +63,12 @@
 /*---------------------------------------------------------------------------*/
 /** \name USB configuration
  *
- * The USB pullup is driven by PC2
+ * The USB pullup is driven by PC0 (Felicia = TI CC2538EM)
  *
  * @{
  */
 #define USB_PULLUP_PORT          GPIO_C_NUM
-#define USB_PULLUP_PIN           2 /* For Yanzi Felicia board */
+#define USB_PULLUP_PIN           0 /* PC0 = CC2538EM */
 #define USB_PULLUP_ACTIVE_HIGH   1
 
 /** @} */

--- a/platform/zoul-sparrow/contiki-main.c
+++ b/platform/zoul-sparrow/contiki-main.c
@@ -101,6 +101,20 @@ void MY_APP_INIT_FUNCTION(void);
 #ifdef HAVE_NETSCAN
 #include "netscan.h"
 #endif /* HAVE_NETSCAN */
+#if PLATFORM_WITH_DUAL_MODE == 1
+/* The state of the operation mode is stored in contiki-main */
+static dual_mode_op_mode_t op_mode = DUAL_MODE_OP_MODE_STANDARD;
+/*---------------------------------------------------------------------------*/
+/*
+ * Return the current operation mode of the mote.
+ */
+dual_mode_op_mode_t
+dual_mode_get_op_mode(void)
+{
+  return op_mode;
+}
+/*---------------------------------------------------------------------------*/
+#endif /* PLATFORM_WITH_DUAL_MODE */
 /*---------------------------------------------------------------------------*/
 /** \brief Board specific iniatialisation */
 void board_init(void);
@@ -161,6 +175,10 @@ set_rf_params(void)
 int
 main(void)
 {
+#if PLATFORM_WITH_DUAL_MODE && USB_SERIAL_CONF_ENABLE
+  struct timer detect_usb_timer;
+#endif
+
   nvic_init();
   ioc_init();
   sys_ctrl_init();
@@ -210,6 +228,24 @@ main(void)
 
   process_start(&etimer_process, NULL);
   ctimer_init();
+
+#if PLATFORM_WITH_DUAL_MODE && USB_SERIAL_CONF_ENABLE
+  /* wait for USB enumeration to happen for 5 seconds */
+  timer_set(&detect_usb_timer, CLOCK_SECOND * 5);
+
+    do {
+      uint8_t is_usb_attached(void);
+
+      process_run();
+
+      if(is_usb_attached())
+      {
+         /* switch to serial radio mode if the usb is attached to host */
+         op_mode = DUAL_MODE_OP_MODE_SERIAL_RADIO;
+         break;
+      }
+    } while(!timer_expired(&detect_usb_timer));
+#endif
 
   queuebuf_init();
 

--- a/products/sparrow-dual-mode/Makefile
+++ b/products/sparrow-dual-mode/Makefile
@@ -1,0 +1,41 @@
+SPARROW=../..
+CONTIKI=$(SPARROW)/contiki
+CONTIKI_PROJECT = dual-op-mode
+
+all: $(CONTIKI_PROJECT)
+
+APPS += slip-cmd
+APPS += sparrow-oam sparrow-beacon
+APPS += sparrow-instances/instance-flash
+APPS += sparrow-instances/instance-leds
+APPS += sparrow-instances/instance-nstats
+
+ifeq ($(TARGET),)
+  -include Makefile.target
+endif
+
+ifeq ($(TARGET),)
+ ${error The serial radio can not be built for the native platform.}
+endif
+
+ifeq ($(TARGET),native)
+ ${error The serial radio can not be built for the native platform.}
+endif
+
+ifeq ($(TARGET),native-sparrow)
+ ${error The serial radio can not be built for the native platform.}
+endif
+
+# Include sourcefiles from serial radio
+CFLAGS += -DPROJECT_CONF_H=\"project-conf.h\"
+SPARROW_OAM_INSTANCES += instance_radio
+PROJECT_SOURCEFILES += instance-radio.c transmit-buffer.c
+PROJECT_SOURCEFILES += enc-net.c no-framer.c sniffer-rdc.c radio-scan.c
+PROJECT_SOURCEFILES += serial-radio.c
+# Include proxy modules
+PROJECT_SOURCEFILES += dual-mode-net.c dual-mode-rdc.c
+
+CONTIKIDIRS += ../sparrow-serial-radio
+
+CONTIKI_WITH_IPV6 = 1
+include $(SPARROW)/Makefile.sparrow

--- a/products/sparrow-dual-mode/dual-mode-net.c
+++ b/products/sparrow-dual-mode/dual-mode-net.c
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2015, Yanzi Networks AB.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+/**
+ * \file
+ *         A NETSTACK_NETWORK proxy for Yanzi IoT Dongle to support
+ *         dual operation mode.
+ * \author
+ *         Ioannis Glaropoulos <ioannisg@kth.se>
+ */
+
+#include "net/netstack.h"
+#include <string.h>
+
+#ifndef DUAL_MODE_SERIAL_RADIO_NETWORK_DRIVER
+#define DUAL_MODE_SERIAL_RADIO_NETWORK_DRIVER encnet_driver
+#endif /* DUAL_MODE_SERIAL_RADIO_NETWORK_DRIVER */
+
+#ifndef DUAL_MODE_STANDARD_MODE_NETWORK_DRIVER
+#define DUAL_MODE_STANDARD_MODE_NETWORK_DRIVER sicslowpan_driver
+#endif /* DUAL_MODE_SERIAL_RADIO_NETWORK_DRIVER */
+
+extern const struct network_driver DUAL_MODE_SERIAL_RADIO_NETWORK_DRIVER;
+extern const struct network_driver DUAL_MODE_STANDARD_MODE_NETWORK_DRIVER;
+
+/*---------------------------------------------------------------------------*/
+static void
+init(void)
+{
+  if(dual_mode_get_op_mode() == DUAL_MODE_OP_MODE_STANDARD) {
+    DUAL_MODE_STANDARD_MODE_NETWORK_DRIVER.init();
+  } else {
+    /* Serial radio mode */
+    DUAL_MODE_SERIAL_RADIO_NETWORK_DRIVER.init();
+  }
+}
+/*---------------------------------------------------------------------------*/
+static void
+packet_input(void)
+{
+  if(dual_mode_get_op_mode() == DUAL_MODE_OP_MODE_STANDARD) {
+    DUAL_MODE_STANDARD_MODE_NETWORK_DRIVER.input();
+  } else {
+    /* Serial radio mode */
+    DUAL_MODE_SERIAL_RADIO_NETWORK_DRIVER.input();
+  }
+}
+/*---------------------------------------------------------------------------*/
+const struct network_driver dual_mode_net_driver = {
+  "Dual mode net driver",
+  init,
+  packet_input,
+};
+/*---------------------------------------------------------------------------*/

--- a/products/sparrow-dual-mode/dual-mode-rdc.c
+++ b/products/sparrow-dual-mode/dual-mode-rdc.c
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2015, Yanzi Networks AB.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+/**
+ * \file
+ *         A RDC proxy to support both serial radio and standard (node) operation.
+ * \author
+ *         Ioannis Glaropoulos <ioannisg@kth.se>
+ */
+
+#include "net/netstack.h"
+#include <string.h>
+#include "dev/leds.h"
+
+
+#ifndef DUAL_MODE_SERIAL_RADIO_RDC_DRIVER
+#define DUAL_MODE_SERIAL_RADIO_RDC_DRIVER sniffer_rdc_driver
+#endif /* DUAL_MODE_SERIAL_RADIO_RDC_DRIVER */
+
+#ifndef DUAL_MODE_STANDARD_MODE_RDC_DRIVER
+#define DUAL_MODE_STANDARD_MODE_RDC_DRIVER nullrdc_driver
+#endif /* DUAL_MODE_STANDARD_MODE_RDC_DRIVER */
+
+#ifndef DUAL_MODE_SERIAL_RADIO_FRAMER
+#define DUAL_MODE_SERIAL_RADIO_FRAMER no_framer
+#endif /* DUAL_MODE_SERIAL_RADIO_FRAMER */
+
+#ifndef DUAL_MODE_STANDARD_MODE_FRAMER
+#define DUAL_MODE_STANDARD_MODE_FRAMER framer_802154
+#endif /* DUAL_MODE_STANDARD_MODE_FRAMER */
+
+extern const struct rdc_driver DUAL_MODE_SERIAL_RADIO_RDC_DRIVER;
+extern const struct rdc_driver DUAL_MODE_STANDARD_MODE_RDC_DRIVER;
+extern const struct framer DUAL_MODE_SERIAL_RADIO_FRAMER;
+extern const struct framer DUAL_MODE_STANDARD_MODE_FRAMER;
+
+static const struct rdc_driver *current_rdc_driver;
+static const struct framer *current_framer;
+/*---------------------------------------------------------------------------*/
+static void
+packet_input(void)
+{
+  current_rdc_driver->input();
+}
+/*---------------------------------------------------------------------------*/
+static void
+send_packet(mac_callback_t sent, void *ptr)
+{
+  current_rdc_driver->send(sent, ptr);
+}
+/*---------------------------------------------------------------------------*/
+static void
+send_list(mac_callback_t sent, void *ptr, struct rdc_buf_list *buf_list)
+{
+  current_rdc_driver->send_list(sent, ptr, buf_list);
+}
+/*---------------------------------------------------------------------------*/
+static int
+on(void)
+{
+  return current_rdc_driver->on();
+}
+/*---------------------------------------------------------------------------*/
+static int
+off(int keep_radio_on)
+{
+  return current_rdc_driver->off(keep_radio_on);
+}
+/*---------------------------------------------------------------------------*/
+static unsigned short
+channel_check_interval(void)
+{
+  return current_rdc_driver->channel_check_interval();
+}
+/*---------------------------------------------------------------------------*/
+static void
+init(void)
+{
+  if(dual_mode_get_op_mode() == DUAL_MODE_OP_MODE_STANDARD) {
+    DUAL_MODE_STANDARD_MODE_RDC_DRIVER.init();
+    current_framer = &(DUAL_MODE_STANDARD_MODE_FRAMER);
+    current_rdc_driver = &(DUAL_MODE_STANDARD_MODE_RDC_DRIVER);
+  } else {
+    DUAL_MODE_SERIAL_RADIO_RDC_DRIVER.init();
+    current_framer = &(DUAL_MODE_SERIAL_RADIO_FRAMER);
+    current_rdc_driver = &(DUAL_MODE_SERIAL_RADIO_RDC_DRIVER);
+  }
+}
+/*---------------------------------------------------------------------------*/
+const struct rdc_driver dual_mode_rdc_driver = {
+  "dual mode rdc",
+  init,
+  send_packet,
+  send_list,
+  packet_input,
+  on,
+  off,
+  channel_check_interval,
+};
+/*---------------------------------------------------------------------------*/
+static int
+hdr_length(void)
+{
+  return current_framer->length();
+}
+/*---------------------------------------------------------------------------*/
+static int
+create(void)
+{
+  return current_framer->create();
+}
+/*---------------------------------------------------------------------------*/
+static int
+parse(void)
+{
+  return current_framer->parse();
+}
+/*---------------------------------------------------------------------------*/
+const struct framer dual_mode_framer = {
+  hdr_length,
+  create,
+  parse,
+};
+/*---------------------------------------------------------------------------*/

--- a/products/sparrow-dual-mode/dual-op-mode.c
+++ b/products/sparrow-dual-mode/dual-op-mode.c
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2015, Yanzi Networks AB.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holders nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ *    This product includes software developed by Yanzi Networks AB.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ * USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include "contiki.h"
+#include "net/llsec/llsec802154.h"
+#include "usb/usb-serial.h"
+#include "serial-radio.h"
+#include "net/llsec/noncoresec/noncoresec.h"
+
+#define DEBUG 1
+#if DEBUG
+#include <stdio.h>
+#define PRINTF(...) printf(__VA_ARGS__)
+#else
+#define PRINTF(...)
+#endif /* DEBUG */
+
+PROCESS_NAME(serial_radio_process);
+PROCESS(dual_mode, "dual mode");
+AUTOSTART_PROCESSES(&dual_mode);
+
+uint8_t *USB_SERIAL_RADIO_GET_PRODUCT_DESCRIPTION(void);
+
+struct product {
+  uint8_t size;
+  uint8_t type;
+  uint16_t string[25];
+};
+
+/* Use generic product name */
+static const struct product product = {
+  sizeof(product),
+  3,
+  {
+    'D','u','a','l','-','o','p',' ','N','o','d','e',' ','M','o','d','e'
+  }
+};
+
+uint8_t *
+dual_mode_get_product_description(void)
+{
+  if(dual_mode_get_op_mode() == DUAL_MODE_OP_MODE_STANDARD) {
+    return (uint8_t *)&product;
+  }
+  return USB_SERIAL_RADIO_GET_PRODUCT_DESCRIPTION();
+}
+/*---------------------------------------------------------------------------*/
+PROCESS_THREAD(dual_mode, ev, data)
+{
+  static struct etimer timer;
+
+  PROCESS_BEGIN();
+
+  if(dual_mode_get_op_mode() == DUAL_MODE_OP_MODE_STANDARD) {
+    while(1) {
+      etimer_set(&timer, CLOCK_SECOND * 5);
+      PROCESS_WAIT_EVENT();
+    }
+  } else {
+    /* Serial radio mode */
+
+#if 0 /* FIXME: missing run time function for setting LLSEC security level */
+    /* Disable encryption in serial radio - controlled by border router */
+    noncoresec_set_security_level(0);
+#endif
+
+#if SLIP_ARCH_CONF_USB || DBG_CONF_USB
+    /* No USB write timeout when running as serial radio */
+    usb_serial_set_write_timeout(0);
+#endif
+
+    process_start(&serial_radio_process, NULL);
+  }
+  PROCESS_END();
+}

--- a/products/sparrow-dual-mode/project-conf.h
+++ b/products/sparrow-dual-mode/project-conf.h
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2010, Swedish Institute of Computer Science.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#ifndef PROJECT_CONF_H_
+#define PROJECT_CONF_H_
+
+/* #define USB_SERIAL_CONF_ENABLE   1 */ /* Needed in IoT-U10 remote mode */
+#define SLIP_ARCH_CONF_USB       1
+#define DBG_CONF_USB             1 /* command output uses debug output */
+#define LPM_CONF_ENABLE          0 /* serial radio never in low-power mode */
+
+/* Use different product description for USB */
+#define USB_SERIAL_RADIO_GET_PRODUCT_DESCRIPTION serial_radio_get_product_description
+#define USB_SERIAL_GET_PRODUCT_DESCRIPTION dual_mode_get_product_description
+
+#define STORE_LOCATIONID_LOCALLY 1
+
+#define FRAMER_802154_HANDLER handler_802154_frame_received
+
+/* FIXME check if this is really needed */
+#undef QUEUEBUF_CONF_NUM
+#define QUEUEBUF_CONF_NUM        4
+
+#define CMD_CONF_OUTPUT serial_radio_cmd_output
+#define CMD_CONF_ERROR  serial_radio_cmd_error
+
+/* A generic RDC driver for IoT-U10 with run-time module selection */
+#undef NETSTACK_CONF_RDC
+#define NETSTACK_CONF_RDC dual_mode_rdc_driver
+
+/* A generic NETWORK driver for IoT-U10 with run-time module selection */
+#undef NETSTACK_CONF_NETWORK
+#define NETSTACK_CONF_NETWORK dual_mode_net_driver
+
+/* A generic FRAMER for IoT-U10 with run-time module selection */
+#undef NETSTACK_CONF_FRAMER
+#define NETSTACK_CONF_FRAMER dual_mode_framer
+
+/* Default serial radio watchdog for radio frontpanel in seconds */
+#define RADIO_FRONTPANEL_WATCHDOG_RESET_VALUE (60 * 60)
+
+/* Network statistics */
+#define RPL_CONF_STATS 1
+
+/* Enable mode selection in run-time */
+#define PLATFORM_WITH_DUAL_MODE 1
+typedef enum {
+  DUAL_MODE_OP_MODE_STANDARD      = 0,
+  DUAL_MODE_OP_MODE_SERIAL_RADIO  = 1,
+} dual_mode_op_mode_t;
+/* Return the current operation mode of a mote. */
+dual_mode_op_mode_t dual_mode_get_op_mode(void);
+
+#define PRODUCTTYPE_INT64_SERIAL_RADIO 0x0090DA0301010482ULL
+#define PRODUCTTYPE_INT64_STANDARD_MODE 0x0090DA0301010501ULL
+/* Default product type for trailer is, now, set to the serial radio */
+#define PRODUCT_TYPE_INT64 0x0090DA0301010482ULL
+/* product-type is used in run-time only, so the following macro should return the right number. */
+#define PRODUCTTYPE_INT64 ((dual_mode_get_op_mode() == DUAL_MODE_OP_MODE_STANDARD) ? (PRODUCTTYPE_INT64_STANDARD_MODE) : (PRODUCTTYPE_INT64_SERIAL_RADIO))
+
+#if 0
+#define PRODUCT_LABEL_SERIAL_RADIO  "Serial Radio"
+#define PRODUCT_LABEL_STANDARD_MODE "Node"
+#define PRODUCT_LABEL ((dual_mode_get_op_mode() == DUAL_MODE_OP_MODE_STANDARD) ? (PRODUCT_LABEL_STANDARD_MODE) : (PRODUCT_LABEL_SERIAL_RADIO))
+#else
+#define PRODUCT_LABEL "Dual-Op-Mode"
+#endif
+
+#define SERIAL_RADIO_CONTROL_API_VERSION 3L
+
+#endif /* PROJECT_CONF_H_ */

--- a/products/sparrow-serial-radio/serial-radio.c
+++ b/products/sparrow-serial-radio/serial-radio.c
@@ -434,7 +434,7 @@ serial_radio_send_packet(uint8_t id)
   /* parse frame before sending to get addresses, etc. */
   packet_ids[packet_pos] = id;
 
-  no_framer.parse();
+  NETSTACK_FRAMER.parse();
   NETSTACK_MAC.send(packet_sent, &packet_ids[packet_pos]);
 
   packet_pos++;

--- a/products/sparrow-serial-radio/serial-radio.c
+++ b/products/sparrow-serial-radio/serial-radio.c
@@ -188,7 +188,7 @@ test_callback(void *ptr)
 }
 #endif /* HAVE_SERIAL_RADIO_UART */
 /*---------------------------------------------------------------------------*/
-#ifdef CONTIKI_TARGET_FELICIA
+#if defined(CONTIKI_TARGET_FELICIA) || (PLATFORM_WITH_DUAL_MODE)
 /* Use different product name for USB on platform Felicia */
 struct product {
   uint8_t size;
@@ -207,7 +207,7 @@ serial_radio_get_product_description(void)
 {
   return (uint8_t *)&product;
 }
-#endif /* CONTIKI_TARGET_FELICIA */
+#endif /* defined(CONTIKI_TARGET_FELICIA) || (PLATFORM_WITH_DUAL_MODE)*/
 /*---------------------------------------------------------------------------*/
 static sniffer_rdc_filter_op_t
 sniffer_callback(void)


### PR DESCRIPTION
**Upstreamed features:-**
- Automatic dual-op mode
  - BOARD=iot-10 (TESTED, OK)
  - BOARD=felicia (TI CC2538) (TESTED, OK)
  - BOARD=iot-u10plus (NOT TESTED)
  - BOARD=iot-u42 (NOT TESTED)
  - BOARD=remote (NOT TESTED)
  - BOARD=firefly (NOT TESTED)
- CoAP resources for examples/iot-u10
- Simple web server for examples/iot-u10
- Some other minor bug fixes

**Limitation of Automatic dual op mode**: Serial radio mode might not work if LLSEC security is enabled because LLSEC security should be disabled in run time in serial radio mode. To solve this problem, LLSEC should support security level settings in run time.
