### PR TITLE
Fix LWM2M endpoint name being truncated when it's too long

### DIFF
--- a/apps/oma-lwm2m/lwm2m-engine.c
+++ b/apps/oma-lwm2m/lwm2m-engine.c
@@ -656,8 +656,8 @@ lwm2m_engine_init(void)
 
   len = strlen(LWM2M_ENGINE_CLIENT_ENDPOINT_PREFIX);
   /* ensure that this fits with the hex-nums */
-  if(len > sizeof(client) - 13) {
-    len = sizeof(client) - 13;
+  if(len > sizeof(client) - 19) {
+    len = sizeof(client) - 19;
   }
   memcpy(client, LWM2M_ENGINE_CLIENT_ENDPOINT_PREFIX, len);
 
@@ -672,6 +672,7 @@ lwm2m_engine_init(void)
     }
   }
 
+  client[len++] = '-';
   if(ipaddr != NULL) {
     for(i = 0; i < 6; i++) {
       /* assume IPv6 for now */


### PR DESCRIPTION
LWM2M endpoint name is not being truncated properly when the BOARD_STRING is too long. 
For example, BOARD_STRING with "Zolertia RE-Mote platform" will cause the endpoint name being truncated to "**Zolertia RE-Mote pl4B00060**". Some of the least significant bytes of ipv6 address are lost. This result in multiple nodes register themselves to LWM2M server with the same endpoint name. This has caused the LWM2M server to overwrite the same single entry with multiple clients and result in only 1 single client registered to the LWM2M server,