### PR TITLE
apps/mote-res: Fixed compilation error due to misplaced of definition

### DIFF
--- a/apps/mote-res/resources-common/print-temperature.c
+++ b/apps/mote-res/resources-common/print-temperature.c
@@ -30,9 +30,7 @@
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
-#if PLATFORM_HAS_SENSORS
 #include "contiki-conf.h"
-#endif
 
 /*---------------------------------------------------------------------------*/
 uint16_t


### PR DESCRIPTION
A minor fix for the compilation error when compiling felicia/iot-u10 and zoul/remote examples.

If possible, merge this PR asap.