### PR TITLE
Bugs fixes on OTA firmware upgrade & CC2538EM serial radio over UART

### DIFF
--- a/examples/sparrow/httpd.py
+++ b/examples/sparrow/httpd.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright (c) 2015-2016, Yanzi Networks AB.
 # All rights reserved.

--- a/examples/sparrow/wsdemoserver.py
+++ b/examples/sparrow/wsdemoserver.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright (c) 2015-2016, Yanzi Networks AB.
 # All rights reserved.

--- a/platform/felicia/cc2538em/board.h
+++ b/platform/felicia/cc2538em/board.h
@@ -77,6 +77,19 @@
  *
  * @{
  */
+#if WITH_UART_FLOW_CONTROL
+#define UART1_RX_PORT            GPIO_A_NUM
+#define UART1_RX_PIN             0
+
+#define UART1_TX_PORT            GPIO_A_NUM
+#define UART1_TX_PIN             1
+
+#define UART1_CTS_PORT           GPIO_B_NUM
+#define UART1_CTS_PIN            0
+
+#define UART1_RTS_PORT           GPIO_D_NUM
+#define UART1_RTS_PIN            3
+#else
 #define UART0_RX_PORT            GPIO_A_NUM
 #define UART0_RX_PIN             0
 
@@ -88,6 +101,7 @@
 
 /* #define UART0_RTS_PORT           GPIO_B_NUM */
 /* #define UART0_RTS_PIN            5 */
+#endif
 /** @} */
 /*---------------------------------------------------------------------------*/
 /**

--- a/products/sparrow-serial-radio/Makefile
+++ b/products/sparrow-serial-radio/Makefile
@@ -34,6 +34,15 @@ ifeq ($(TARGET),zoul-sparrow)
   endif
 endif
 
+ifeq ($(BOARD),cc2538em)
+  ifdef MAKE_WITH_UART
+    CFLAGS += -DWITH_UART=1
+  else ifdef MAKE_WITH_UART_FLOW_CONTROL
+    CFLAGS += -DWITH_UART=1
+    CFLAGS += -DWITH_UART_FLOW_CONTROL=1
+  endif
+endif
+
 #linker optimizations
 SMALL=1
 

--- a/products/sparrow-serial-radio/project-conf.h
+++ b/products/sparrow-serial-radio/project-conf.h
@@ -65,6 +65,14 @@
 #define DBG_CONF_USB             0 /* command output uses debug output */
 #define SLIP_ARCH_CONF_USB       0
 
+#if WITH_UART_FLOW_CONTROL
+#define SERIAL_LINE_CONF_UART       1 /**< UART to use with serial line */
+#define SLIP_ARCH_CONF_UART         1 /**< UART to use with SLIP */
+#define DBG_CONF_UART               1 /**< UART to use for debugging */
+#define UART1_CONF_UART             1 /**< UART to use for examples relying on
+                                           the uart1_* API */
+#endif
+
 #else /* WITH_UART */
 
 #define DBG_CONF_USB             1 /* command output uses debug output */

--- a/tools/sparrow/binfiletool.py
+++ b/tools/sparrow/binfiletool.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright (c) 2016, SICS, Swedish ICT
 # All rights reserved.

--- a/tools/sparrow/deviceserver.py
+++ b/tools/sparrow/deviceserver.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright (c) 2015-2016, Yanzi Networks AB.
 # All rights reserved.

--- a/tools/sparrow/instance-gen.py
+++ b/tools/sparrow/instance-gen.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright (c) 2016, SICS, Swedish ICT
 # All rights reserved.

--- a/tools/sparrow/instance-vars.py
+++ b/tools/sparrow/instance-vars.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright (c) 2016, SICS, Swedish ICT
 # All rights reserved.
@@ -51,6 +51,3 @@ def load_vars(yaml_file):
 if __name__ == "__main__":
     with open(sys.argv[1], 'r') as yaml_file:
         load_vars(yaml_file)
-
-
-

--- a/tools/sparrow/leds.py
+++ b/tools/sparrow/leds.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright (c) 2015-2016, SICS, Swedish ICT
 # All rights reserved.

--- a/tools/sparrow/nstatslib.py
+++ b/tools/sparrow/nstatslib.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright (c) 2015-2016, Yanzi Networks AB.
 # All rights reserved.

--- a/tools/sparrow/serialradio.py
+++ b/tools/sparrow/serialradio.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright (c) 2013-2016, Yanzi Networks
 # All rights reserved.

--- a/tools/sparrow/sniff.py
+++ b/tools/sparrow/sniff.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright (c) 2013-2016, Yanzi Networks
 # All rights reserved.

--- a/tools/sparrow/tlvdiscovery.py
+++ b/tools/sparrow/tlvdiscovery.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright (c) 2013-2016, SICS, Swedish ICT
 # All rights reserved.

--- a/tools/sparrow/tlvlib.py
+++ b/tools/sparrow/tlvlib.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright (c) 2013-2016, SICS, Swedish ICT
 # All rights reserved.

--- a/tools/sparrow/tlvlib.py
+++ b/tools/sparrow/tlvlib.py
@@ -841,7 +841,7 @@ def discovery(host, port=UDP_PORT):
     t3 = create_get_tlv32(0, VARIABLE_NUMBER_OF_INSTANCES)
     # get the boot timer
     t4 = create_get_tlv64(0, VARIABLE_UNIT_BOOT_TIMER)
-    enc,tlvs = send_tlv([t1,t2,t3,t4], host, port)
+    enc,tlvs = send_tlv([t1,t2,t3,t4], host, port, timeout=3.0)
     product_type = tlvs[0].int_value
     product_label = convert_string(tlvs[1].value)
     num_instances = tlvs[2].int_value

--- a/tools/sparrow/tlvupgrade.py
+++ b/tools/sparrow/tlvupgrade.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright (c) 2016, SICS, Swedish ICT
 # All rights reserved.

--- a/tools/sparrow/trailertool.py
+++ b/tools/sparrow/trailertool.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright (c) 2016, SICS, Swedish ICT
 # All rights reserved.


### PR DESCRIPTION
Fix bugs on OTA firmware upgrade re-flash mechanism. When flash segments upgrade failed for the first time, the script has problem re-flash the failed segments for the subsequent time. It is due to logic errors in the code using python dictionary.

**_Desired feature for OTA firmware uprade: Allow user to specify the TLV timeout in command options for those network that has slower response time such as network running @ subGHz._**

User can now use serial radio over UART with CC2538EM. A simple schematic diagram will be provided in wiki page to help user with this configurations. This is particular useful for those sparrow users who wish to design their own 6LoWPAN gateway with built-in serial radio running over UART @ up to 912kbps with hardware flow control. The default baud rate is **460800**. User can replace the **SERIAL_BAUDRATE** with their desired baud rate in **product/sparrow-serial-radio/project-conf.h**.