### PR TITLE
Bug fixes for OTA scripts &sparrow serial radio + tinydtls submodule update

### DIFF
--- a/examples/zoul/remote/Makefile
+++ b/examples/zoul/remote/Makefile
@@ -3,7 +3,10 @@ CONTIKI=$(SPARROW)/contiki
 CONTIKI_PROJECT = remote
 
 TARGET=zoul-sparrow
-BOARD=remote-reva
+
+ifeq ($(BOARD),)
+  BOARD=remote-reva
+endif
 
 CFLAGS += -DPROJECT_CONF_H=\"project-conf.h\"
 

--- a/products/sparrow-serial-radio/Makefile
+++ b/products/sparrow-serial-radio/Makefile
@@ -29,8 +29,8 @@ ifeq ($(TARGET),native-sparrow)
 endif
 
 ifeq ($(TARGET),zoul-sparrow)
-  ifdef USE_DEBUG_PORT
-    CFLAGS += -DZOUL_SPARROW_USB_DEBUG_PORT
+  ifdef MAKE_WITH_USB_PORT
+    CFLAGS += -DWITH_USB_PORT=1
   endif
 endif
 

--- a/products/sparrow-serial-radio/project-conf.h
+++ b/products/sparrow-serial-radio/project-conf.h
@@ -35,13 +35,11 @@
  */
 #ifdef CONTIKI_TARGET_ZOUL_SPARROW
 
-/* Use UART by default on Zoul platforms unless USB_DEBUG_PORT is set */
+/* Use UART by default on Zoul platforms unless WITH_USB_PORT is set */
 #ifndef WITH_UART
-#if defined(ZOUL_SPARROW_USB_DEBUG_PORT) || defined(SLIP_ARCH_CONF_USB)
-#define WITH_UART 0
-#else
+#if !defined(WITH_USB_PORT) && !defined(SLIP_ARCH_CONF_USB)
 #define WITH_UART 1
-#endif /* ZOUL_SPARROW_USB_DEBUG_PORT */
+#endif /* !defined(WITH_USB_PORT) && !defined(SLIP_ARCH_CONF_USB) */
 #endif /* WITH_UART */
 
 #endif /* CONTIKI_TARGET_ZOUL_SPARROW */

--- a/products/sparrow-serial-radio/serial-radio.c
+++ b/products/sparrow-serial-radio/serial-radio.c
@@ -190,7 +190,7 @@ test_callback(void *ptr)
 }
 #endif /* HAVE_SERIAL_RADIO_UART */
 /*---------------------------------------------------------------------------*/
-#if defined(CONTIKI_TARGET_FELICIA) || (PLATFORM_WITH_DUAL_MODE) || (defined(CONTIKI_TARGET_ZOUL_SPARROW) && !defined(ZOUL_SPARROW_USB_DEBUG_PORT))
+#if defined(CONTIKI_TARGET_FELICIA) || (PLATFORM_WITH_DUAL_MODE) || (defined(CONTIKI_TARGET_ZOUL_SPARROW) && defined(WITH_USB_PORT))
 /* Use different product name for USB on platform Felicia */
 struct product {
   uint8_t size;

--- a/tools/sparrow/tlvupgrade.py
+++ b/tools/sparrow/tlvupgrade.py
@@ -148,7 +148,7 @@ def do_upgrade(data, instance, host, port, block_size, retry_passes=50):
     i = 0
     while i < retry_passes and segments > 0:
         i += 1
-        print "Writing", i, len(to_upgrade.keys()), "left to go.", "\b" * 35,
+        print "Writing", i, segments, "left to go.", "\b" * 35,
         sys.stdout.flush()
         for udata in to_upgrade:
             if to_upgrade[udata] is not None:


### PR DESCRIPTION
- Fix minor mistake of printing the incorrect remaining flash segments while upgrading node's firmware in OTA scripts.

- Removed USE_USB_DEBUG_PORT for sparrow serial radio when compiling for zoul-sparrow platform and replaced it with MAKE_WITH_USB_PORT. If this MAKE_WITH_USB_PORT is specified when using 'make' command. It will compile the sparrow serial radio to use USB port instead of UART which is also known as DEBUG port for Zolertia RE-MOTE. This option is mainly for RE-MOTE user who wish to switch different port (DBG <--> USB). DBG Port on RE-MOTE is actually UART connected to serial to USB converter.

- Update tinydtls submodule for better CC2538 platform support