### PR TITLE
sparrow-dual-mode: Bug fixes and netscan support

### DIFF
--- a/examples/zoul/remote/Makefile
+++ b/examples/zoul/remote/Makefile
@@ -23,6 +23,10 @@ APPS += rest-engine
 APPS += mote-res/resources-coap
 APPS += mote-res/resources-common
 
+ifdef MAKE_WITH_NETSCAN
+APPS += netscan
+endif
+
 ifdef MAKE_WITH_WEBSERVER
 APPS += mote-res/resources-web
 endif

--- a/platform/felicia/contiki-main.c
+++ b/platform/felicia/contiki-main.c
@@ -299,15 +299,14 @@ main(void)
 
 #if NETSTACK_CONF_WITH_IPV6
   memcpy(&uip_lladdr.addr, &linkaddr_node_addr, sizeof(uip_lladdr.addr));
-  process_start(&tcpip_process, NULL);
-#if PLATFORM_WITH_DUAL_MODE == 1
+#if PLATFORM_WITH_DUAL_MODE
   if(op_mode == DUAL_MODE_OP_MODE_STANDARD) {
     /* tcpip_process does not start when in serial-radio mode */
     process_start(&tcpip_process, NULL);
   }
-#else /* PLATFORM_WITH_DUAL_MODE == 1 */
+#else /* PLATFORM_WITH_DUAL_MODE */
   process_start(&tcpip_process, NULL);
-#endif /* PLATFORM_WITH_DUAL_MODE == 1 */
+#endif /* PLATFORM_WITH_DUAL_MODE */
 #endif /* NETSTACK_CONF_WITH_IPV6 */
 
   adc_init();
@@ -325,7 +324,14 @@ main(void)
 #endif /* HAVE_SPARROW_OAM */
 
 #ifdef HAVE_NETSCAN
+#if PLATFORM_WITH_DUAL_MODE
+  if(op_mode == DUAL_MODE_OP_MODE_STANDARD) {
+    /* netscan does not start when in serial-radio mode */
+    netscan_init();
+  }
+#else /* PLATFORM_WITH_DUAL_MODE */
   netscan_init();
+#endif /* PLATFORM_WITH_DUAL_MODE */
 #endif /* HAVE_NETSCAN */
 
   watchdog_start();

--- a/platform/zoul-sparrow/contiki-main.c
+++ b/platform/zoul-sparrow/contiki-main.c
@@ -353,7 +353,14 @@ main(void)
 
 #if NETSTACK_CONF_WITH_IPV6
   memcpy(&uip_lladdr.addr, &linkaddr_node_addr, sizeof(uip_lladdr.addr));
+#if PLATFORM_WITH_DUAL_MODE
+  if(op_mode == DUAL_MODE_OP_MODE_STANDARD) {
+    /* tcpip_process does not start when in serial-radio mode */
+    process_start(&tcpip_process, NULL);
+  }
+#else /* PLATFORM_WITH_DUAL_MODE */
   process_start(&tcpip_process, NULL);
+#endif /* PLATFORM_WITH_DUAL_MODE */
 #endif /* NETSTACK_CONF_WITH_IPV6 */
 
   process_start(&sensors_process, NULL);
@@ -370,7 +377,14 @@ main(void)
 #endif /* HAVE_SPARROW_OAM */
 
 #ifdef HAVE_NETSCAN
+#if PLATFORM_WITH_DUAL_MODE
+  if(op_mode == DUAL_MODE_OP_MODE_STANDARD) {
+    /* netscan does not start when in serial-radio mode */
+    netscan_init();
+  }
+#else /* PLATFORM_WITH_DUAL_MODE */
   netscan_init();
+#endif /* PLATFORM_WITH_DUAL_MODE */
 #endif /* HAVE_NETSCAN */
 
   watchdog_start();

--- a/products/sparrow-dual-mode/Makefile
+++ b/products/sparrow-dual-mode/Makefile
@@ -12,6 +12,10 @@ APPS += sparrow-instances/instance-leds
 endif
 APPS += sparrow-instances/instance-nstats
 
+ifdef MAKE_WITH_NETSCAN
+APPS += netscan
+endif
+
 ifeq ($(TARGET),)
   -include Makefile.target
 endif


### PR DESCRIPTION
- (Fix) prevent starting **tcpip_process** when dual-op-mode work as serial radio
- add netscan support for dual-op-mode and zoul-sparrow platform
- Under dual-op-mode, netscan process will only be started when working as node.

**TODO: The netscan don't work in SubGHz. Netscan need to be disabled automatically for now when node is running at SubGHz.**