### PR TITLE
Explicitly set the serial radio to use the same PANID as the border router

### DIFF
--- a/products/sparrow-border-router/border-router.c
+++ b/products/sparrow-border-router/border-router.c
@@ -412,6 +412,19 @@ border_router_set_frontpanel_info(uint16_t info)
   write_to_slip(buf, 5);
 }
 /*---------------------------------------------------------------------------*/
+void
+border_router_set_panid(uint16_t pan_id)
+{
+  uint8_t buf[4];
+  buf[0] = '!';
+  buf[1] = 'P';
+  buf[2] = (pan_id >> 8) & 0xff;
+  buf[3] = pan_id & 0xff;
+  write_to_slip(buf, 4);
+
+  border_router_radio_set_value(RADIO_PARAM_PAN_ID, pan_id);
+}
+/*---------------------------------------------------------------------------*/
 static uint8_t pending_on;
 static uint8_t pending_off;
 static unsigned int original_baudrate;
@@ -736,6 +749,9 @@ PROCESS_THREAD(border_router_process, ev, data)
   /* Have all info from radio, init OAM and UDP server */
   udp_cmd_start();
   sparrow_oam_init();
+
+  /* Make sure the serial radio is set to the same PANID as we are. */
+  border_router_set_panid(frame802154_get_pan_id());
 
   if(radio_control_version == 0) {
     border_router_request_radio_version();

--- a/products/sparrow-border-router/border-router.h
+++ b/products/sparrow-border-router/border-router.h
@@ -90,6 +90,7 @@ void border_router_set_radio_watchdog(uint16_t seconds);
 void border_router_set_radio_mode(uint8_t mode);
 uint8_t border_router_get_radio_mode(void);
 void border_router_set_frontpanel_info(uint16_t info);
+void border_router_set_panid(uint16_t pan_id);
 void border_router_request_radio_version(void);
 void border_router_request_radio_time(void);
 void border_router_print_stat(void);


### PR DESCRIPTION
Currently, the PAN ID **must** be configured identical in the border router and in the serial radio. This is not a big problem as long as you stay with the default. But if the PAN ID configuration is changed in one, but not the other, then strange things happen.

One example of strange behaviour: Change the PAN ID configuration of the serial radio, but keep the border router at the default PAN ID (i.e., no config change). When you try this out, it is natural to check the PAN ID setting in the command line interface with "?P". BUT, that command **copies** the configured PAN ID setting from the serial radio to the border router as a side effect! And therefore, everything seems fine, when they are not.

Therefore, I suggest that the PAN ID **must** be configured in the border router, and that the border router explicitly sets the PAN ID of the serial radio. This also takes care of the special case when the serial radio configuration is changed in the command line interface, and then the border router is restarted while the serial radio just keeps running.

This patch implements my suggestion.