### PR TITLE
Trun harmless GCC error into warning

### DIFF
--- a/products/sparrow-serial-radio/Makefile
+++ b/products/sparrow-serial-radio/Makefile
@@ -6,7 +6,7 @@ all: $(CONTIKI_PROJECT)
 
 APPS = slip-cmd sparrow-oam sparrow-beacon
 APPS += sparrow-instances/instance-flash
-CFLAGS += -Werror
+CFLAGS += -Werror -Wno-error=tautological-compare
 
 SPARROW_OAM_LOCAL_INSTANCES += instance_radio
 


### PR DESCRIPTION
Compile using ARM GCC 6 results in error:
error: self-comparison always evaluates to true [-Wtautological-compare]
   if(&NETSTACK_RADIO == &cc2538_rf_driver)