### PR TITLE
Added radio parameter for radio name for more generic radio management

### DIFF
--- a/core/dev/radio.h
+++ b/core/dev/radio.h
@@ -183,6 +183,11 @@ enum {
    * it needs to be used with radio.get_object()/set_object(). */
   RADIO_PARAM_LAST_PACKET_TIMESTAMP,
 
+  /*
+   * Optional name of the radio as a string.
+   */
+  RADIO_PARAM_NAME,
+
   /* Constants (read only) */
 
   /* The lowest radio channel. */

--- a/cpu/cc2538/dev/cc2538-rf.c
+++ b/cpu/cc2538/dev/cc2538-rf.c
@@ -1342,6 +1342,13 @@ get_object(radio_param_t param, void *dest, size_t size)
     return RADIO_RESULT_OK;
   }
 
+  if(param == RADIO_PARAM_NAME && size > 0) {
+    strncpy(dest, "CC2538", size);
+    /* Ensure the string is terminated */
+    ((char *)dest)[size - 1] = '\0';
+    return RADIO_RESULT_OK;
+  }
+
   return RADIO_RESULT_NOT_SUPPORTED;
 }
 /*---------------------------------------------------------------------------*/

--- a/dev/cc1200/cc1200.c
+++ b/dev/cc1200/cc1200.c
@@ -1313,6 +1313,13 @@ static radio_result_t
 get_object(radio_param_t param, void *dest, size_t size)
 {
 
+  if(param == RADIO_PARAM_NAME && size > 0) {
+    strncpy(dest, "CC1200", size);
+    /* Ensure the string is terminated */
+    ((char *)dest)[size - 1] = '\0';
+    return RADIO_RESULT_OK;
+  }
+
   return RADIO_RESULT_NOT_SUPPORTED;
 
 }

--- a/platform/felicia/contiki-main.c
+++ b/platform/felicia/contiki-main.c
@@ -180,7 +180,6 @@ set_rf_params(void)
 
   NETSTACK_RADIO.set_value(RADIO_PARAM_PAN_ID, IEEE802154_PANID);
   NETSTACK_RADIO.set_value(RADIO_PARAM_16BIT_ADDR, short_addr);
-  NETSTACK_RADIO.set_value(RADIO_PARAM_CHANNEL, CC2538_RF_CHANNEL);
   NETSTACK_RADIO.set_object(RADIO_PARAM_64BIT_ADDR, ext_addr, 8);
 }
 /*---------------------------------------------------------------------------*/

--- a/platform/felicia/contiki-main.c
+++ b/platform/felicia/contiki-main.c
@@ -147,8 +147,6 @@ dual_mode_get_op_mode(void)
 /*---------------------------------------------------------------------------*/
 #endif /* PLATFORM_WITH_DUAL_MODE */
 
-char *sparrow_radio_name = NULL;
-
 /*---------------------------------------------------------------------------*/
 /** \brief Board specific iniatialisation */
 void board_init(void);
@@ -167,20 +165,42 @@ set_rf_params(void)
   /* Populate linkaddr_node_addr. Maintain endianness */
   memcpy(&linkaddr_node_addr, &ext_addr[8 - LINKADDR_SIZE], LINKADDR_SIZE);
 
+  NETSTACK_RADIO.set_value(RADIO_PARAM_PAN_ID, IEEE802154_PANID);
+  NETSTACK_RADIO.set_value(RADIO_PARAM_16BIT_ADDR, short_addr);
+  NETSTACK_RADIO.set_object(RADIO_PARAM_64BIT_ADDR, ext_addr, 8);
+
 #if STARTUP_CONF_VERBOSE
   {
     int i;
+    radio_value_t channel = 0;
+    char buf[32];
+
     printf("Network configured with ll address ");
     for(i = 0; i < LINKADDR_SIZE - 1; i++) {
       printf("%02x:", linkaddr_node_addr.u8[i]);
     }
     printf("%02x\n", linkaddr_node_addr.u8[i]);
-  }
-#endif
 
-  NETSTACK_RADIO.set_value(RADIO_PARAM_PAN_ID, IEEE802154_PANID);
-  NETSTACK_RADIO.set_value(RADIO_PARAM_16BIT_ADDR, short_addr);
-  NETSTACK_RADIO.set_object(RADIO_PARAM_64BIT_ADDR, ext_addr, 8);
+    PRINTF(" Net: %s\n", NETSTACK_NETWORK.name);
+    PRINTF(" MAC: %s\n", NETSTACK_MAC.name);
+    PRINTF(" RDC: %s\n", NETSTACK_RDC.name);
+
+    /* Get the radio name if available */
+    if(NETSTACK_RADIO.get_object(RADIO_PARAM_NAME, buf, sizeof(buf)) ==
+                                 RADIO_RESULT_OK) {
+      buf[sizeof(buf) - 1] = '\0';
+      PRINTF(" PHY: %s\n", buf);
+    }
+
+    PRINTF(" PAN-ID: 0x%04x\n", IEEE802154_PANID);
+
+    /* Get the radio channel */
+    NETSTACK_RADIO.get_value(RADIO_PARAM_CHANNEL, &channel);
+    PRINTF(" RF Channel: %d\n", channel);
+
+    PRINTF(" Compiled @ %s %s\n", __DATE__, __TIME__);
+  }
+#endif /* STARTUP_CONF_VERBOSE */
 }
 /*---------------------------------------------------------------------------*/
 /**
@@ -283,18 +303,6 @@ main(void)
 
   netstack_init();
   set_rf_params();
-
-  PRINTF(" Net: ");
-  PRINTF("%s\n", NETSTACK_NETWORK.name);
-  PRINTF(" MAC: ");
-  PRINTF("%s\n", NETSTACK_MAC.name);
-  PRINTF(" RDC: ");
-  PRINTF("%s\n", NETSTACK_RDC.name);
-  PRINTF(" PHY: %s\n",
-         &NETSTACK_RADIO == &cc2538_rf_driver ? "CC2538_RF" : "CC1200");
-  PRINTF(" PAN-ID: 0x%04x\n", IEEE802154_PANID);
-  PRINTF(" RF Channel: %u\n", CC2538_RF_CONF_CHANNEL);
-  PRINTF(" Compiled @ %s %s\n", __DATE__, __TIME__);
 
 #if NETSTACK_CONF_WITH_IPV6
   memcpy(&uip_lladdr.addr, &linkaddr_node_addr, sizeof(uip_lladdr.addr));

--- a/platform/felicia/dev/cc1200-arch.c
+++ b/platform/felicia/dev/cc1200-arch.c
@@ -184,7 +184,7 @@ cc1200_arch_gpio0_setup_irq(int rising)
 
   GPIO_ENABLE_INTERRUPT(CC1200_GDO0_PORT_BASE, CC1200_GDO0_PIN_MASK);
   ioc_set_over(CC1200_GDO0_PORT, CC1200_GDO0_PIN, IOC_OVERRIDE_PUE);
-  nvic_interrupt_enable(CC1200_GPIOx_VECTOR);
+  NVIC_EnableIRQ(CC1200_GPIOx_VECTOR);
   gpio_register_callback(cc1200_int_handler, CC1200_GDO0_PORT,
                          CC1200_GDO0_PIN);
 }
@@ -206,7 +206,7 @@ cc1200_arch_gpio2_setup_irq(int rising)
 
   GPIO_ENABLE_INTERRUPT(CC1200_GDO2_PORT_BASE, CC1200_GDO2_PIN_MASK);
   ioc_set_over(CC1200_GDO2_PORT, CC1200_GDO2_PIN, IOC_OVERRIDE_PUE);
-  nvic_interrupt_enable(CC1200_GPIOx_VECTOR);
+  NVIC_EnableIRQ(CC1200_GPIOx_VECTOR);
   gpio_register_callback(cc1200_int_handler, CC1200_GDO2_PORT,
                          CC1200_GDO2_PIN);
 }
@@ -217,7 +217,7 @@ cc1200_arch_gpio0_enable_irq(void)
 {
   GPIO_ENABLE_INTERRUPT(CC1200_GDO0_PORT_BASE, CC1200_GDO0_PIN_MASK);
   ioc_set_over(CC1200_GDO0_PORT, CC1200_GDO0_PIN, IOC_OVERRIDE_PUE);
-  nvic_interrupt_enable(CC1200_GPIOx_VECTOR);
+  NVIC_EnableIRQ(CC1200_GPIOx_VECTOR);
 }
 /*---------------------------------------------------------------------------*/
 void
@@ -232,7 +232,7 @@ cc1200_arch_gpio2_enable_irq(void)
 {
   GPIO_ENABLE_INTERRUPT(CC1200_GDO2_PORT_BASE, CC1200_GDO2_PIN_MASK);
   ioc_set_over(CC1200_GDO2_PORT, CC1200_GDO2_PIN, IOC_OVERRIDE_PUE);
-  nvic_interrupt_enable(CC1200_GPIOx_VECTOR);
+  NVIC_EnableIRQ(CC1200_GPIOx_VECTOR);
 }
 #endif /* CC1200_USE_GPIO2 */
 /*---------------------------------------------------------------------------*/
@@ -247,14 +247,14 @@ cc1200_arch_gpio2_disable_irq(void)
 int
 cc1200_arch_gpio0_read_pin(void)
 {
-  return GPIO_READ_PIN(CC1200_GDO0_PORT_BASE, CC1200_GDO0_PIN_MASK);
+  return (GPIO_READ_PIN(CC1200_GDO0_PORT_BASE, CC1200_GDO0_PIN_MASK) ? 1 : 0);
 }
 /*---------------------------------------------------------------------------*/
 #if CC1200_USE_GPIO2
 int
 cc1200_arch_gpio2_read_pin(void)
 {
-  return GPIO_READ_PIN(CC1200_GDO2_PORT_BASE, CC1200_GDO2_PIN_MASK);
+  return (GPIO_READ_PIN(CC1200_GDO2_PORT_BASE, CC1200_GDO2_PIN_MASK) ? 1 : 0);
 }
 #endif /* CC1200_USE_GPIO2 */
 /*---------------------------------------------------------------------------*/

--- a/platform/zoul-sparrow/contiki-main.c
+++ b/platform/zoul-sparrow/contiki-main.c
@@ -227,10 +227,6 @@ set_rf_params(void)
 
   NETSTACK_RADIO.set_value(RADIO_PARAM_PAN_ID, IEEE802154_PANID);
   NETSTACK_RADIO.set_value(RADIO_PARAM_16BIT_ADDR, short_addr);
-  if(&NETSTACK_RADIO == &cc2538_rf_driver)
-    NETSTACK_RADIO.set_value(RADIO_PARAM_CHANNEL, CC2538_RF_CHANNEL);
-  else
-    NETSTACK_RADIO.set_value(RADIO_PARAM_CHANNEL, CC1200_DEFAULT_CHANNEL);
   NETSTACK_RADIO.set_object(RADIO_PARAM_64BIT_ADDR, ext_addr, 8);
 }
 /*---------------------------------------------------------------------------*/

--- a/platform/zoul-sparrow/contiki-main.c
+++ b/platform/zoul-sparrow/contiki-main.c
@@ -120,8 +120,6 @@ dual_mode_get_op_mode(void)
 #endif /* PLATFORM_WITH_DUAL_MODE */
 /*---------------------------------------------------------------------------*/
 
-char *sparrow_radio_name = NULL;
-
 /** \brief Board specific iniatialisation */
 void board_init(void);
 /*---------------------------------------------------------------------------*/
@@ -214,20 +212,42 @@ set_rf_params(void)
   /* Populate linkaddr_node_addr. Maintain endianness */
   memcpy(&linkaddr_node_addr, &ext_addr[8 - LINKADDR_SIZE], LINKADDR_SIZE);
 
+  NETSTACK_RADIO.set_value(RADIO_PARAM_PAN_ID, IEEE802154_PANID);
+  NETSTACK_RADIO.set_value(RADIO_PARAM_16BIT_ADDR, short_addr);
+  NETSTACK_RADIO.set_object(RADIO_PARAM_64BIT_ADDR, ext_addr, 8);
+
 #if STARTUP_CONF_VERBOSE
   {
     int i;
+    radio_value_t channel = 0;
+    char buf[32];
+
     printf("Network configured with ll address ");
     for(i = 0; i < LINKADDR_SIZE - 1; i++) {
       printf("%02x:", linkaddr_node_addr.u8[i]);
     }
     printf("%02x\n", linkaddr_node_addr.u8[i]);
-  }
-#endif
 
-  NETSTACK_RADIO.set_value(RADIO_PARAM_PAN_ID, IEEE802154_PANID);
-  NETSTACK_RADIO.set_value(RADIO_PARAM_16BIT_ADDR, short_addr);
-  NETSTACK_RADIO.set_object(RADIO_PARAM_64BIT_ADDR, ext_addr, 8);
+    PRINTF(" Net: %s\n", NETSTACK_NETWORK.name);
+    PRINTF(" MAC: %s\n", NETSTACK_MAC.name);
+    PRINTF(" RDC: %s\n", NETSTACK_RDC.name);
+
+    /* Get the radio name if available */
+    if(NETSTACK_RADIO.get_object(RADIO_PARAM_NAME, buf, sizeof(buf)) ==
+                                 RADIO_RESULT_OK) {
+      buf[sizeof(buf) - 1] = '\0';
+      PRINTF(" PHY: %s\n", buf);
+    }
+
+    PRINTF(" PAN-ID: 0x%04x\n", IEEE802154_PANID);
+
+    /* Get the radio channel */
+    NETSTACK_RADIO.get_value(RADIO_PARAM_CHANNEL, &channel);
+    PRINTF(" RF Channel: %d\n", channel);
+
+    PRINTF(" Compiled @ %s %s\n", __DATE__, __TIME__);
+  }
+#endif /* STARTUP_CONF_VERBOSE */
 }
 /*---------------------------------------------------------------------------*/
 /**
@@ -333,19 +353,6 @@ main(void)
   queuebuf_init();
   netstack_init();
   set_rf_params();
-
-  PRINTF(" Net: ");
-  PRINTF("%s\n", NETSTACK_NETWORK.name);
-  PRINTF(" MAC: ");
-  PRINTF("%s\n", NETSTACK_MAC.name);
-  PRINTF(" RDC: ");
-  PRINTF("%s\n", NETSTACK_RDC.name);
-  sparrow_radio_name =  &NETSTACK_RADIO == &cc2538_rf_driver ? "CC2538_RF" : "CC1200";
-  PRINTF(" PHY: %s\n",
-         &NETSTACK_RADIO == &cc2538_rf_driver ? "CC2538_RF" : "CC1200");
-  PRINTF(" PAN-ID: 0x%04x\n", IEEE802154_PANID);
-  PRINTF(" RF Channel: %u\n", &NETSTACK_RADIO == &cc2538_rf_driver ? CC2538_RF_CHANNEL : CC1200_DEFAULT_CHANNEL);
-  PRINTF(" Compiled @ %s %s\n", __DATE__, __TIME__);
 
 #if NETSTACK_CONF_WITH_IPV6
   memcpy(&uip_lladdr.addr, &linkaddr_node_addr, sizeof(uip_lladdr.addr));

--- a/products/sparrow-serial-radio/serial-radio.c
+++ b/products/sparrow-serial-radio/serial-radio.c
@@ -62,8 +62,6 @@
 #error "No SERIAL_RADIO_CONTROL_API_VERSION specified. Please set in project-conf.h!"
 #endif
 
-extern char *sparrow_radio_name;
-
 #ifdef CONTIKI_BOARD_IOT_U42
 extern const struct radio_driver cc2538_rf_driver;
 extern const struct radio_driver cc1200_driver;
@@ -845,25 +843,15 @@ serial_radio_cmd_handler(const uint8_t *data, int len)
       }
 #endif /* HAVE_SERIAL_RADIO_UART */
 
-      if(sparrow_radio_name != NULL) {
-        printf("PHY: %s\n", sparrow_radio_name);
-      } else {
-        printf("PHY: unknown\n");
+      {
+        char buf[32];
+        if(NETSTACK_RADIO.get_object(RADIO_PARAM_NAME, buf, sizeof(buf)) ==
+           RADIO_RESULT_OK) {
+          buf[sizeof(buf) - 1] = '\0';
+          printf("PHY: %s\n", buf);
+        }
       }
 
-#ifdef CONTIKI_BOARD_IOT_U42
-      {
-        const char *name;
-        if(&NETSTACK_RADIO == &cc2538_rf_driver) {
-          name = "CC2538 RF";
-        } else if(&NETSTACK_RADIO == &cc1200_driver) {
-          name = "CC1200";
-        } else {
-          name = "unknown";
-        }
-        printf("PHY: %s\n", name);
-      }
-#endif /* CONTIKI_BOARD_IOT_U42 */
 #ifdef HAVE_RADIO_FRONTPANEL
       {
         uint32_t r = radio_get_reset_cause();


### PR DESCRIPTION
As described in #27, ARM GCC 6.2 warns for the radio driver comparisons used to differentiate which radio is currently active. This PR avoids the issue by adding a radio parameter in the radio driver and updating the code to simply ask the radio driver for any needed information.