### PR TITLE
Made the Sparrow Makefile use MODULES to include source files in build.

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -68,7 +68,7 @@ TARGET_BOARD_UPPERCASE := ${strip ${shell echo $(BOARD) | sed y!$(LOWERCASE)!$(U
 CFLAGS += -DCONTIKI_BOARD_$(TARGET_BOARD_UPPERCASE)=1
 endif
 
-MODULES += core/sys core/dev core/lib
+MODULES += core core/sys core/dev core/lib
 
 # Include IPv6, IPv4, and/or Rime
 
@@ -109,8 +109,7 @@ endif
 
 CONTIKI_SOURCEFILES += $(CONTIKIFILES)
 
-CONTIKIDIRS += ${addprefix $(CONTIKI)/core/,dev lib net net/llsec net/mac net/rime \
-                 net/rpl sys cfs ctk lib/ctk loader . }
+CONTIKIDIRS += ${addprefix $(CONTIKI)/core/,cfs loader}
 
 oname = ${patsubst %.c,%.o,${patsubst %.S,%.o,$(1)}}
 
@@ -156,9 +155,9 @@ endif
 
 ifdef MODULES
   UNIQUEMODULES = $(call uniq,$(MODULES))
-  MODULEDIRS = ${wildcard ${addprefix $(CONTIKI)/, $(UNIQUEMODULES)}}
+  MODULEDIRS = ${wildcard ${addprefix $(SPARROW)/, $(UNIQUEMODULES)} ${addprefix $(CONTIKI)/, $(UNIQUEMODULES)}}
   MODULES_SOURCES = ${foreach d, $(MODULEDIRS), ${subst ${d}/,,${wildcard $(d)/*.c}}}
-  CONTIKI_SOURCEFILES += $(MODULES_SOURCES)
+  CONTIKI_SOURCEFILES += $(call uniq,$(MODULES_SOURCES))
   APPDS += $(MODULEDIRS)
 endif
 

--- a/Makefile.sparrow
+++ b/Makefile.sparrow
@@ -8,10 +8,6 @@ endif
 
 SPARROW_TOOLS=$(SPARROW)/tools/sparrow
 
-SPARROWDIRS += $(SPARROW)/core ${addprefix $(SPARROW)/core/,dev net net/ip net/ipv6 net/rpl net/mac net/mac/tsch sys lib}
-CONTIKIDIRS += $(SPARROWDIRS)
-CONTIKI_SOURCEFILES += ${notdir ${wildcard ${addsuffix /*.c,$(SPARROWDIRS)}}}
-
 APPDIRS     += $(SPARROW)/apps
 TARGETDIRS  += $(SPARROW)/platform
 


### PR DESCRIPTION
This allows better control of which files are included in the build and solves a compile issues where the iot-u10 example could not be compiled with LLSEC enabled due to conflict with TSCH security configuration.