### PR TITLE
made Zoul platform and sparrow-border-router configurable for subghz …

### DIFF
--- a/apps/sparrow-oam/sparrow-defaults.h
+++ b/apps/sparrow-oam/sparrow-defaults.h
@@ -94,7 +94,9 @@
 
 #define RPL_CONF_NOPATH_REMOVAL_DELAY               60
 
+#ifndef SICSLOWPAN_CONF_MAC_MAX_PAYLOAD
 #define SICSLOWPAN_CONF_MAC_MAX_PAYLOAD      (127 - 2)
+#endif
 #define SICSLOWPAN_CONF_COMPRESSION_THRESHOLD        0
 #define SICSLOWPAN_CONF_FRAG                         1
 /* Timeout for packet reassembly at the 6LoWPAN layer (1/16 seconds) */

--- a/core/net/ipv6/sicslowpan.c
+++ b/core/net/ipv6/sicslowpan.c
@@ -255,7 +255,8 @@ static uint16_t my_tag;
 #ifdef SICSLOWPAN_CONF_FRAGMENT_SIZE
 #define SICSLOWPAN_FRAGMENT_SIZE SICSLOWPAN_CONF_FRAGMENT_SIZE
 #else
-#define SICSLOWPAN_FRAGMENT_SIZE 110
+/* The default fragment size (110 bytes for 127-2 bytes frames) */
+#define SICSLOWPAN_FRAGMENT_SIZE (MAC_MAX_PAYLOAD - 15)
 #endif
 
 /* Assuming that the worst growth for uncompression is 38 bytes */

--- a/dev/cc1200/cc1200.c
+++ b/dev/cc1200/cc1200.c
@@ -2320,7 +2320,7 @@ cc1200_rx_interrupt(void)
     }
 
     burst_read(CC1200_RXFIFO,
-               &phr,
+               (uint8_t *) &phr,
                PHR_LEN);
     payload_len = (phr.phra & 0x07);
     payload_len <<= 8;

--- a/platform/zoul-sparrow/contiki-conf.h
+++ b/platform/zoul-sparrow/contiki-conf.h
@@ -359,10 +359,15 @@ typedef uint32_t rtimer_clock_t;
 #define NULLRDC_CONF_MAX_RETRANSMISSIONS        3
 #define NULLRDC_CONF_ENABLE_RETRANSMISSIONS_BCAST 1
 
+#define PACKETBUF_CONF_SIZE             255
+#define SICSLOWPAN_CONF_MAC_MAX_PAYLOAD 253
+
 #define NETSTACK_CONF_RADIO         cc1200_driver
-#define CC1200_CONF_USE_GPIO2       0
+#define CC1200_CONF_MAX_PAYLOAD_LEN 255
+#define CC1200_CONF_USE_GPIO2       1
 #define CC1200_CONF_USE_RX_WATCHDOG 0
 #define ANTENNA_SW_SELECT_DEF_CONF  ANTENNA_SW_SELECT_SUBGHZ
+#define CC1200_CONF_802154G         1
 #else
 /* Configure NullRDC for when it's selected - cc2538-rf has autoretrans... */
 #define NULLRDC_802154_AUTOACK                  0
@@ -370,6 +375,10 @@ typedef uint32_t rtimer_clock_t;
 
 #if WITH_920
 #define CC1200_CONF_RF_CFG          cc1200_802154g_920_928_fsk_50kbps
+#define CC1200_CONF_DEFAULT_CHANNEL 0
+#endif
+#if WITH_868
+#define CC1200_CONF_RF_CFG          cc1200_802154g_863_870_fsk_50kbps
 #define CC1200_CONF_DEFAULT_CHANNEL 0
 #endif
 

--- a/products/sparrow-border-router/Makefile
+++ b/products/sparrow-border-router/Makefile
@@ -22,6 +22,10 @@ TARGET=native-sparrow
 #linker optimizations
 SMALL=1
 
+ifneq ($(MAKE_WITH_SUBGHZ),)
+   CFLAGS += -DWITH_SUBGHZ=1
+endif
+
 CFLAGS += -Werror
 # OSX (g)cc does not like  -Wunused-but-set-variable
 ifneq ($(HOST_OS),Darwin)

--- a/products/sparrow-border-router/project-conf.h
+++ b/products/sparrow-border-router/project-conf.h
@@ -63,6 +63,13 @@
 #undef QUEUEBUF_CONF_NUM
 #define QUEUEBUF_CONF_NUM         32
 
+
+#ifdef WITH_SUBGHZ
+/* If using 802.15.4g - we need to set later packet sizes */
+#define PACKETBUF_CONF_SIZE             255
+#define SICSLOWPAN_CONF_MAC_MAX_PAYLOAD 253
+#endif
+
 #undef SICSLOWPAN_CONF_FRAGMENT_BUFFERS
 #define SICSLOWPAN_CONF_FRAGMENT_BUFFERS 64
 


### PR DESCRIPTION
…802.15.4g with large packets, 255 bytes

This is for making the Zoul platform in sparrow use 802.15.4g packet formats and able to make use of 255 bytes frames rather than 127 bytes. This includes fixes to Sparrow-border-router so that it also supports larger frames.
