### PR TITLE
Added command line arguments for radio channel and PANID in Sparrow border router

### DIFF
--- a/products/sparrow-border-router/border-router-cmds.c
+++ b/products/sparrow-border-router/border-router-cmds.c
@@ -142,7 +142,7 @@ hextoi(const uint8_t *buf, int len, int *v)
   return buf;
 }
 /*---------------------------------------------------------------------------*/
-static const uint8_t *
+const uint8_t *
 dectoi(const uint8_t *buf, int len, int *v)
 {
   int negative = 0;
@@ -172,7 +172,7 @@ dectoi(const uint8_t *buf, int len, int *v)
   return buf;
 }
 /*---------------------------------------------------------------------------*/
-static int
+int
 index_of(uint8_t v, const uint8_t *buf, int offset, int len)
 {
   for(; offset < len; offset++) {
@@ -263,19 +263,15 @@ border_router_cmd_handler(const uint8_t *data, int len)
       if(command_context == CMD_CONTEXT_RADIO) {
         /* We need to know that this is from the slip-radio here. */
         YLOG_INFO("Channel is: %d\n", data[2]);
+
+        border_router_radio_set_value(RADIO_PARAM_CHANNEL, data[2]);
         return 1;
       }
       if(command_context == CMD_CONTEXT_STDIO) {
         int channel = -1;
         dectoi(&data[2], len - 2, &channel);
         if(channel >= 0) {
-          uint8_t buf[5];
-          buf[0] = '!';
-          buf[1] = 'C';
-          buf[2] = channel & 0xff;
-          write_to_slip(buf, 3);
-
-          border_router_radio_set_value(RADIO_PARAM_CHANNEL, channel);
+          border_router_set_channel(channel);
           return 1;
         }
         YLOG_ERROR("*** illegal channel: %u\n", channel);
@@ -394,15 +390,8 @@ border_router_cmd_handler(const uint8_t *data, int len)
         int pan_id;
         dectoi(&data[2], len - 2, &pan_id);
         /* printf("PAN ID: %u (%04x)\n", pan_id, pan_id); */
-        uint8_t buf[5];
-        buf[0] = '!';
-        buf[1] = 'P';
-        buf[2] = (pan_id >> 8) & 0xff;
-        buf[3] = pan_id & 0xff;
-        write_to_slip(buf, 4);
+        border_router_set_panid(pan_id & 0xffff);
         handler_802154_join(pan_id);
-
-        border_router_radio_set_value(RADIO_PARAM_PAN_ID, pan_id);
         return 1;
       }
       return 1;

--- a/products/sparrow-border-router/border-router.c
+++ b/products/sparrow-border-router/border-router.c
@@ -626,19 +626,18 @@ PROCESS_THREAD(border_router_process, ev, data)
 
   PROCESS_BEGIN();
 
+  prefix_set = 0;
+  dis = 2; /* send a couple of DIS at startup to detect any existing network */
+
+  br_config_handle_arguments(contiki_argc, contiki_argv);
+
+  YLOG_INFO("RPL-Border router started\n");
+
   watchdog_init();
   /* Start watchdog immediately */
   /* watchdog_start(); */
 
-  prefix_set = 0;
-  dis = 2; /* send a couple of DIS at startup to detect any existing network */
-
   PROCESS_PAUSE();
-
-  watchdog_periodic();
-
-  YLOG_INFO("RPL-Border router started\n");
-  br_config_handle_arguments(contiki_argc, contiki_argv);
 
   YLOG_DEBUG("Registering Join Callback\n");
   rpl_set_join_callback(br_join_dag);

--- a/products/sparrow-border-router/border-router.h
+++ b/products/sparrow-border-router/border-router.h
@@ -91,6 +91,7 @@ void border_router_set_radio_mode(uint8_t mode);
 uint8_t border_router_get_radio_mode(void);
 void border_router_set_frontpanel_info(uint16_t info);
 void border_router_set_panid(uint16_t pan_id);
+void border_router_set_channel(uint16_t channel);
 void border_router_request_radio_version(void);
 void border_router_request_radio_time(void);
 void border_router_print_stat(void);

--- a/products/sparrow-border-router/br-config.h
+++ b/products/sparrow-border-router/br-config.h
@@ -32,6 +32,8 @@
 
 #include <stdint.h>
 
+extern int br_config_radio_channel;
+extern int br_config_radio_panid;
 extern uint8_t br_config_wait_for_address;
 extern uint8_t br_config_verbose_output;
 extern const char *br_config_ipaddr;


### PR DESCRIPTION
This PR adds the option to specify radio channel and PANID as command line arguments when starting the border router:

`./border-router.native-sparrow -Dchannel=26 -Dpanid=0xabcd`

Also, the border router will now show the packet TX/RX times in the TX/RX log output.